### PR TITLE
Specify bitcoin network in lnd conf

### DIFF
--- a/charts/lnd/templates/configmap.yaml
+++ b/charts/lnd/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "lnd.labels" . | nindent 4 }}
 data:
   lnd.conf: |-
+    bitcoin.{{ .Values.global.network }}=true
   {{ printf "%s=%s" "bitcoind.rpcpass" (include "bitcoind.rpcpassword" . ) | indent 2 }}
   {{- range .Values.lndGeneralConfig }}
     {{ . }}


### PR DESCRIPTION
When installing lnd via
```
$ helm install lnd galoy/lnd --set global.network=regtest
$ kubectl logs -f lnd-0
(...)
loadConfig: either --bitcoin.mainnet, or bitcoin.testnet, bitcoin.simnet, or bitcoin.regtest must be specified
(...)
```

shows that the config regarding which network connect to is missing.
After this is fixed it still doesn't start completely but I'm making tiny PRs addressing the issues step by step.

Related to https://github.com/GaloyMoney/charts/issues/13