### PR TITLE
No rpcpassword generation

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bitcoind/templates/_helpers.tpl
+++ b/charts/bitcoind/templates/_helpers.tpl
@@ -62,19 +62,3 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-
-{{- define "rpcpassword" -}}
-
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace "bitcoind-rpcpassword") -}}
-{{- if $secret -}}
-{{/*
-   Reusing current password since secret exists
-*/}}
-{{-  $secret.data.password | b64dec -}}
-{{- else -}}
-{{/*
-    Generate new password
-*/}}
-{{- randAlpha 24 -}}
-{{- end -}}
-{{- end -}}

--- a/charts/bitcoind/templates/configmap.yaml
+++ b/charts/bitcoind/templates/configmap.yaml
@@ -22,12 +22,3 @@ data:
     {{ printf "%s=%s" $k $v}}
     {{- end }}
   {{- end}}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: bitcoind-rpcpassword
-  labels:
-    {{- include "bitcoind.labels" . | nindent 4 }}
-stringData:
-  password: {{ $rpcpassword }}

--- a/charts/bitcoind/templates/configmap.yaml
+++ b/charts/bitcoind/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{ $rpcpassword := include "rpcpassword" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/bitcoind/templates/configmap.yaml
+++ b/charts/bitcoind/templates/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- include "bitcoind.labels" . | nindent 4 }}
 data:
   bitcoin.conf: |-
-  {{ printf "rpcpassword=%s" $rpcpassword | indent 2 }}
   {{- range .Values.bitcoindGenericConfig }}
     {{ . }}
   {{- end }}

--- a/charts/bitcoind/templates/secrets.yaml
+++ b/charts/bitcoind/templates/secrets.yaml
@@ -1,0 +1,11 @@
+{{ $rpcpassword := include "rpcpassword" . }}
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitcoind-rpcpassword
+  labels:
+    {{- include "bitcoind.labels" . | nindent 4 }}
+stringData:
+  password: {{ $rpcpassword }}
+{{- end }}

--- a/charts/bitcoind/templates/secrets.yaml
+++ b/charts/bitcoind/templates/secrets.yaml
@@ -1,4 +1,3 @@
-{{ $rpcpassword := include "rpcpassword" . }}
 {{- if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
@@ -7,5 +6,5 @@ metadata:
   labels:
     {{- include "bitcoind.labels" . | nindent 4 }}
 stringData:
-  password: {{ $rpcpassword }}
+  password: {{ .Values.bitcoindRpcPassword }}
 {{- end }}

--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -37,10 +37,19 @@ spec:
       initContainers:
         - name: copy-bitcoind-config
           image: busybox
-          command: ['sh', '-c', 'cp /configmap/bitcoin.conf /data/.bitcoin/bitcoin.conf']
+          command:
+          - 'sh'
+          - '-c'
+          - |
+            cat <<EOF > /data/.bitcoin/bitcoin.conf
+            rpcpassword=$(cat /rpcpassword/password)
+            $(cat /configmap/bitcoin.conf)
+            EOF
           volumeMounts:
             - name: configmap
               mountPath: /configmap
+            - name: rpcpassword
+              mountPath: /rpcpassword
             - name: config
               mountPath: /data/.bitcoin/
       containers:
@@ -91,6 +100,9 @@ spec:
       volumes:
         - name: config
           emptyDir: {}
+        - name: rpcpassword
+          secret:
+            secretName: bitcoind-rpcpassword
         - name: configmap
           configMap:
             name: {{ template "bitcoind.fullname" . }}

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -7,6 +7,9 @@ global:
     ports:
       rpc: 8332
 
+secrets:
+  create: true
+
 replicaCount: 1
 
 image:

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -121,6 +121,8 @@ podLabels: {}
 #   - kube-monkey/identifier: {{.Values.bitcoindContainer.name }}
 
 
+bitcoindRpcPassword: rpcpassword
+
 # TODO: Document the usage of generic and custom config to instruct where to put specific flags
 
 bitcoindGenericConfig:

--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu
+
+RUN wget -O- https://carvel.dev/install.sh | bash
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+  && apt-get install -y \
+  tzdata curl make git build-essential lsb-release \
+  libtool autotools-dev autoconf libssl-dev libboost-all-dev \
+  apt-transport-https ca-certificates \
+  gnupg software-properties-common \
+  vim jq rsync wget \
+  && apt-get clean all
+
+ARG BITCOIN_VERSION=0.21.1
+RUN wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && tar -xvf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+  && mv bitcoin-${BITCOIN_VERSION}/bin/* /usr/local/bin && bitcoin-cli -version
+
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+  && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+  && apt-get update && apt-get install -y terraform && apt-get clean
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+            && chmod +x ./kubectl \
+            && mv ./kubectl /usr/local/bin
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+  | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
+  && apt-get update -y \
+  && apt-get install google-cloud-sdk -y
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -44,7 +44,6 @@ jobs:
       image: image/image.tar
 
 - name: bitcoind-testflight
-  serial: true
   plan:
   - in_parallel:
     - { get: bitcoind-chart, trigger: true }
@@ -67,8 +66,6 @@ jobs:
       vars_files: [ testflight/bitcoind/terraform.tfvars ]
       terraform_source: testflight/bitcoind
       env_name_file: testflight/env_name
-      vars:
-        bitcoind_rpcpassword: #@ data.values.testflight_bitcoin_rpcpassword
   - task: smoke-test
     tags: ["staging"]
     config:
@@ -77,8 +74,6 @@ jobs:
       inputs:
       - name: pipeline-tasks
       - name: testflight
-      params:
-        BITCOIN_RPCPASSWORD: #@ data.values.testflight_bitcoin_rpcpassword
       run:
         path: pipeline-tasks/ci/tasks/bitcoind-smoketest.sh
   - put: tf-bitcoind-testflight
@@ -88,8 +83,6 @@ jobs:
       terraform_source: testflight/bitcoind
       env_name_file: testflight/env_name
       action: destroy
-      vars:
-        bitcoind_rpcpassword: #@ data.values.testflight_bitcoin_rpcpassword
     get_params: { action: destroy }
 
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,143 @@
+#@ load("@ytt:data", "data")
+
+#@ def pipeline_image():
+#@   return data.values.docker_registry + "/helm-charts-pipeline"
+#@ end
+
+#@ def task_image_config():
+type: registry-image
+source:
+  username: #@ data.values.docker_registry_user
+  password: #@ data.values.docker_registry_password
+  repository: #@ pipeline_image()
+#@ end
+
+groups:
+- name: bitcoind
+  jobs: [ bitcoind-testflight ]
+- name: image
+  jobs: [ build-pipeline-image ]
+
+jobs:
+- name: build-pipeline-image
+  serial: true
+  plan:
+  - {get: pipeline-image-def, trigger: true}
+  - task: build
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      inputs:
+      - name: pipeline-image-def
+      outputs:
+      - name: image
+      params:
+        CONTEXT: pipeline-image-def/ci/image
+      run:
+        path: build
+  - put: pipeline-image
+    params:
+      image: image/image.tar
+
+- name: bitcoind-testflight
+  serial: true
+  plan:
+  - in_parallel:
+    - { get: bitcoind-chart, trigger: true }
+    - { get: pipeline-tasks }
+  - task: prepare-testflight
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: bitcoind-chart
+        path: repo
+      outputs:
+      - name: testflight
+      run:
+        path: pipeline-tasks/ci/tasks/prepare-testflight.sh
+  - put: tf-bitcoind-testflight
+    tags: ["staging"]
+    params:
+      vars_files: [ testflight/bitcoind/terraform.tfvars ]
+      terraform_source: testflight/bitcoind
+      env_name_file: testflight/env_name
+      vars:
+        bitcoind_rpcpassword: #@ data.values.testflight_bitcoin_rpcpassword
+  - task: smoke-test
+    tags: ["staging"]
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: testflight
+      params:
+        BITCOIN_RPCPASSWORD: #@ data.values.testflight_bitcoin_rpcpassword
+      run:
+        path: pipeline-tasks/ci/tasks/bitcoind-smoketest.sh
+  - put: tf-bitcoind-testflight
+    tags: ["staging"]
+    params:
+      vars_files: [ testflight/bitcoind/terraform.tfvars ]
+      terraform_source: testflight/bitcoind
+      env_name_file: testflight/env_name
+      action: destroy
+      vars:
+        bitcoind_rpcpassword: #@ data.values.testflight_bitcoin_rpcpassword
+    get_params: { action: destroy }
+
+
+resources:
+- name: bitcoind-chart
+  type: git
+  source:
+    paths: [ "charts/bitcoind/**/*" ]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+- name: pipeline-tasks
+  type: git
+  source:
+    paths: [ci/tasks/*, ci/testflight/*, Makefile]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: pipeline-image
+  type: registry-image
+  source:
+    tag: latest
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ pipeline_image()
+- name: pipeline-image-def
+  type: git
+  source:
+    paths: [ci/image/Dockerfile]
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: tf-bitcoind-testflight
+  type: terraform
+  source:
+    backend_type: gcs
+    backend_config:
+      bucket: #@ data.values.staging_state_bucket
+      prefix: galoy-staging/services/bitcoind-testflight
+      credentials: #@ data.values.staging_creds
+    env:
+      GOOGLE_CREDENTIALS: #@ data.values.staging_creds
+
+resource_types:
+- name: terraform
+  type: docker-image
+  source:
+    repository: ljfranklin/terraform-resource
+    tag: latest

--- a/ci/repipe
+++ b/ci/repipe
@@ -10,7 +10,7 @@ fi
 target="${FLY_TARGET:-galoy}"
 team=dev
 
-TMPDIR=""¬
+TMPDIR=""
 TMPDIR=$(mktemp -d -t repipe.XXXXXX)
 trap "rm -rf ${TMPDIR}" INT TERM QUIT EXIT
 

--- a/ci/repipe
+++ b/ci/repipe
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ $(which ytt) == "" ]]; then
+  echo "You will need to install ytt to repipe. https://carvel.dev/ytt/"
+  exit 1
+fi
+
+target="${FLY_TARGET:-galoy}"
+team=dev
+
+TMPDIR=""¬
+TMPDIR=$(mktemp -d -t repipe.XXXXXX)
+trap "rm -rf ${TMPDIR}" INT TERM QUIT EXIT
+
+ytt -f ci > ${TMPDIR}/pipeline.yml
+
+echo "Updating pipeline @ ${target}"
+
+fly -t ${target} set-pipeline --team=${team} -p helm-charts -c ${TMPDIR}/pipeline.yml
+fly -t ${target} unpause-pipeline --team=${team} -p helm-charts

--- a/ci/tasks/bitcoind-smoketest.sh
+++ b/ci/tasks/bitcoind-smoketest.sh
@@ -3,7 +3,7 @@
 bitcoin-cli -version
 bitcoin-cli -testnet \
   -rpcuser=rpcuser \
-  -rpcpassword=${BITCOIN_RPCPASSWORD} \
+  -rpcpassword=rpcpassword \
   -rpcport=18332 \
   -rpcconnect=bitcoind.$(cat testflight/env_name).svc.cluster.local \
   -getinfo

--- a/ci/tasks/bitcoind-smoketest.sh
+++ b/ci/tasks/bitcoind-smoketest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+bitcoin-cli -version
+bitcoin-cli -testnet \
+  -rpcuser=rpcuser \
+  -rpcpassword=${BITCOIN_RPCPASSWORD} \
+  -rpcport=18332 \
+  -rpcconnect=bitcoind.$(cat testflight/env_name).svc.cluster.local \
+  -getinfo

--- a/ci/tasks/prepare-testflight.sh
+++ b/ci/tasks/prepare-testflight.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cp -r pipeline-tasks/ci/testflight/bitcoind testflight/bitcoind
+cp -r repo/charts/bitcoind testflight/bitcoind/chart
+
+cat <<EOF > testflight/bitcoind/terraform.tfvars
+testflight_namespace = "testflight-$(cat repo/.git/short_ref)"
+EOF
+
+cat <<EOF > testflight/env_name
+testflight-$(cat repo/.git/short_ref)
+EOF

--- a/ci/testflight/bitcoind/main.tf
+++ b/ci/testflight/bitcoind/main.tf
@@ -1,0 +1,79 @@
+variable "testflight_namespace" {}
+variable "bitcoind_rpcpassword" {}
+
+locals {
+  cluster_name             = "galoy-staging-cluster"
+  cluster_location         = "us-east1"
+  gcp_project              = "galoy-staging"
+
+  testflight_namespace = var.testflight_namespace
+}
+
+resource "kubernetes_namespace" "testflight" {
+  metadata {
+    name = local.testflight_namespace
+  }
+}
+
+resource "kubernetes_secret" "testflight" {
+  metadata {
+    name = "bitcoind-rpcpassword"
+    namespace  = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = {
+    password = var.bitcoind_rpcpassword
+  }
+}
+
+resource "helm_release" "bitcoind" {
+  name       = "bitcoind"
+  chart      = "./chart"
+  repository = "https://galoymoney.github.io/charts/"
+  namespace  = kubernetes_namespace.testflight.metadata[0].name
+
+  values = [
+    file("${path.module}/testflight-values.yml")
+  ]
+
+  depends_on = [
+    kubernetes_secret.testflight
+  ]
+}
+
+data "google_container_cluster" "primary" {
+  project  = local.gcp_project
+  name     = local.cluster_name
+  location = local.cluster_location
+}
+
+data "google_client_config" "default" {
+  provider = google-beta
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.primary.private_cluster_config.0.private_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+}
+
+provider "kubernetes-alpha" {
+  host                   = "https://${data.google_container_cluster.primary.private_cluster_config.0.private_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.google_container_cluster.primary.private_cluster_config.0.private_endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+terraform {
+  backend "gcs" {
+    bucket = "galoy-staging-tf-state"
+    prefix = "galoy-staging/services/bitcoind-testflight"
+  }
+}

--- a/ci/testflight/bitcoind/main.tf
+++ b/ci/testflight/bitcoind/main.tf
@@ -1,5 +1,4 @@
 variable "testflight_namespace" {}
-variable "bitcoind_rpcpassword" {}
 
 locals {
   cluster_name             = "galoy-staging-cluster"
@@ -15,17 +14,6 @@ resource "kubernetes_namespace" "testflight" {
   }
 }
 
-resource "kubernetes_secret" "testflight" {
-  metadata {
-    name = "bitcoind-rpcpassword"
-    namespace  = kubernetes_namespace.testflight.metadata[0].name
-  }
-
-  data = {
-    password = var.bitcoind_rpcpassword
-  }
-}
-
 resource "helm_release" "bitcoind" {
   name       = "bitcoind"
   chart      = "./chart"
@@ -34,10 +22,6 @@ resource "helm_release" "bitcoind" {
 
   values = [
     file("${path.module}/testflight-values.yml")
-  ]
-
-  depends_on = [
-    kubernetes_secret.testflight
   ]
 }
 

--- a/ci/testflight/bitcoind/testflight-values.yml
+++ b/ci/testflight/bitcoind/testflight-values.yml
@@ -4,9 +4,6 @@ global:
     ports:
       rpc: 18332
 
-secrets:
-  create: false
-
 persistence:
   enabled: true
   size: 50Gi

--- a/ci/testflight/bitcoind/testflight-values.yml
+++ b/ci/testflight/bitcoind/testflight-values.yml
@@ -1,0 +1,24 @@
+global:
+  network: testnet
+  service:
+    ports:
+      rpc: 18332
+
+secrets:
+  create: false
+
+persistence:
+  enabled: true
+  size: 50Gi
+
+service:
+  type: ClusterIP
+  ports:
+    zmqpubrawtx: 28333
+    zmqpubrawblock: 28332
+    p2p: 18333
+
+bitcoindCustomConfig:
+  bind: 0.0.0.0
+  rpcbind: 0.0.0.0
+  rpcallowip: 0.0.0.0/0

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -2,11 +2,10 @@
 ---
 deployments_git_uri: git@github.com:GaloyMoney/galoy-deployments.git
 git_uri: git@github.com:GaloyMoney/charts.git
-git_branch: main
+git_branch: no-rpcpassword-generation
 github_private_key: ((github-ssh-key.private_key))
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))
 docker_registry_password: ((docker-creds.password))
-testflight_bitcoin_rpcpassword: testflight-password
 staging_state_bucket: ((staging.bucket_name))
 staging_creds: ((staging.creds_json))

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,0 +1,12 @@
+#@data/values
+---
+deployments_git_uri: git@github.com:GaloyMoney/galoy-deployments.git
+git_uri: git@github.com:GaloyMoney/charts.git
+git_branch: main
+github_private_key: ((github-ssh-key.private_key))
+docker_registry: us.gcr.io/galoy-org
+docker_registry_user: ((docker-creds.username))
+docker_registry_password: ((docker-creds.password))
+testflight_bitcoin_rpcpassword: testflight-password
+staging_state_bucket: ((staging.bucket_name))
+staging_creds: ((staging.creds_json))


### PR DESCRIPTION
This enables determining the rpcpassword either via values.yml or via pre-provisioning a secret.

Password generation as part of the helm chart is not standard practice.

Potentially breaking change. Must specify:
```
secrets:
  create: false
```
In existing installations to not override the secret.

Build on https://github.com/GaloyMoney/charts/pull/49
Addresses https://github.com/GaloyMoney/charts/issues/44