### PR TITLE
[k3d] create cluster args fixed

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,7 +1,7 @@
 TF:=terraform
 
 create-cluster:
-	k3d cluster create --k3s-server-arg "--disable traefik" --k3s-server-arg "--disable servicelb"
+	k3d cluster create --k3s-server-arg "--disable=traefik" --k3s-server-arg "--disable=servicelb"
 
 delete-cluster:
 	k3d cluster delete


### PR DESCRIPTION
Fixed the k3s server args in the create-cluster command, cluster not waking up issue fixed.
Related Issue: https://github.com/rancher/k3d/issues/742