### PR TITLE
fine tuning the rate limits

### DIFF
--- a/charts/galoy/templates/admin-ingress.yaml
+++ b/charts/galoy/templates/admin-ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ default "ca-issuer" .Values.adminIngress.clusterIssuer }}
-    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-rpm: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "4"
 spec:
   tls:
   - hosts:

--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -11,7 +11,9 @@ metadata:
     {{ if .Values.apiIngress.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.apiIngress.clusterIssuer }}
     {{ end }}
-    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-rpm: "30"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
 spec:
   {{ if .Values.apiIngress.clusterIssuer }}
   tls:

--- a/charts/galoy/templates/graphql-ingress.yaml
+++ b/charts/galoy/templates/graphql-ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ default "ca-issuer" .Values.adminIngress.clusterIssuer }}
-    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-rpm: "30"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "20"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
we previously had higher limit because of a lot of the queries from pay was done with a "polled query", and this was frequent (every 2s). now that we have moved to a subscription, we can tighten those parameters. 

because the `burst-multiplier` is at 20, it still allow 600 simultaneously, which should fit the use case where many people are using the wallet on some shared wifi at the same time. 

documentation from those parameters can be seen here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting

more documentation here: https://www.nginx.com/blog/rate-limiting-nginx/