### PR TITLE
update mongodb to last v4 version

### DIFF
--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 15.3.1
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.25.1
+  version: 10.29.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.8.0
@@ -14,5 +14,5 @@ dependencies:
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 9.5.3
-digest: sha256:b5fa8d146d78582dc0a36b08528a754e9cc77c497b0707d6f24b1fdd53634b86
-generated: "2021-09-12T01:37:30.523477462+05:30"
+digest: sha256:e5b2d62149d83e010ff67b2c4ae487fad4d1584d03181336f0c1f9f46e9886f8
+generated: "2021-11-04T14:02:02.898691Z"

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 15.3.1
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
-    version: 10.25.1
+    version: 10.x.x
   - name: common
     version: 1.8.0
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
PR that goes with: https://github.com/GaloyMoney/galoy/pull/706