### PR TITLE
Mongodb update reproduce

### DIFF
--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 15.3.1
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.25.1
+  version: 10.29.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.8.0
@@ -14,5 +14,5 @@ dependencies:
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 9.5.3
-digest: sha256:b5fa8d146d78582dc0a36b08528a754e9cc77c497b0707d6f24b1fdd53634b86
-generated: "2021-09-12T01:37:30.523477462+05:30"
+digest: sha256:5dd789a218c0642247492f09ca90f1602ddbfa160417962d2393d39ac5530cb3
+generated: "2021-11-05T17:23:19.804708613+05:30"

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     version: 15.3.1
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
-    version: 10.25.1
+    version: 10.29.0
   - name: common
     version: 1.8.0
     repository: https://charts.bitnami.com/bitnami

--- a/dev/galoy/galoy-values.yml
+++ b/dev/galoy/galoy-values.yml
@@ -24,17 +24,6 @@ lnd2:
 
 jwtSecret: "my_non_secured_secret"
 
-mongodb:
-  architecture: standalone
-  volumePermissions:
-    enabled: true
-  persistence:
-    enabled: false
-  replicaCount: 1
-  metrics:
-    enabled: false
-  initDbScripts: {}
-
 redis:
   volumePermissions:
     enabled: true


### PR DESCRIPTION
This branch can reproduce the MongoDB upgrade issue locally.
It only shows up when deploying MongoDB as a replica set. All pods talking to mongo fail with the same log issue

@nicolasburtey @krtk6160 

```
$ k get pods -n galoy-dev-galoy
NAME                                 READY   STATUS             RESTARTS   AGE
galoy-lnpage-55475ddf5-7688s         2/2     Running            0          8m14s
galoy-lnpay-7477d8bdf5-qgfsc         1/1     Running            0          8m14s
galoy-admin-panel-5b6895b974-9dd6l   2/2     Running            0          8m14s
galoy-mongodb-0                      2/2     Running            0          8m14s
galoy-price-68d7bddf8f-jlmp5         1/1     Running            0          8m14s
galoy-mongodb-1                      2/2     Running            0          7m45s
galoy-redis-node-0                   2/2     Running            0          8m14s
galoy-mongodb-2                      2/2     Running            0          7m33s
graphql-admin-7b878bd56c-7rzcq       0/1     CrashLoopBackOff   5          8m14s
exporter-64dffdf4b6-w7km8            0/1     CrashLoopBackOff   5          8m14s
api-647c68b4cf-kmwhw                 0/1     CrashLoopBackOff   5          8m14s
graphql-864d47698b-vrs9v             0/1     CrashLoopBackOff   5          8m14s
trigger-5dc9b88598-8tlsj             0/1     CrashLoopBackOff   5          8m13s
graphql-864d47698b-jfn2d             0/1     CrashLoopBackOff   5          8m14s

$ k -n galoy-dev-galoy logs trigger-5dc9b88598-8tlsj
{"level":30,"time":1636123209234,"pid":1,"hostname":"trigger-5dc9b88598-8tlsj","module":"trigger","msg":"Health check listening on port 8888!"}
{"level":60,"time":1636123239204,"pid":1,"hostname":"trigger-5dc9b88598-8tlsj","err":{"type":"MongooseServerSelectionError","message":"getaddrinfo ENOTFOUND galoy-mongodb","stack":"MongooseServerSelectionError: getaddrinfo ENOTFOUND galoy-mongodb\n    at NativeConnection.Connection.openUri (/app/node_modules/mongoose/lib/connection.js:830:32)\n    at /app/node_modules/mongoose/lib/index.js:342:10\n    at /app/node_modules/mongoose/lib/helpers/promiseOrCallback.js:31:5\n    at new Promise (<anonymous>)\n    at promiseOrCallback (/app/node_modules/mongoose/lib/helpers/promiseOrCallback.js:30:10)\n    at Mongoose._promiseOrCallback (/app/node_modules/mongoose/lib/index.js:1129:10)\n    at Mongoose.connect (/app/node_modules/mongoose/lib/index.js:341:20)\n    at setupMongoConnection (/app/lib/services/mongodb/index.js:33:34)\n    at Object.<anonymous> (/app/lib/servers/trigger.js:239:40)\n    at Module._compile (internal/modules/cjs/loader.js:1085:14)\n    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)\n    at Module.load (internal/modules/cjs/loader.js:950:32)\n    at Function.Module._load (internal/modules/cjs/loader.js:790:12)\n    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)\n    at internal/main/run_main_module.js:17:47","reason":{"type":"Unknown","setName":null,"maxSetVersion":null,"maxElectionId":null,"servers":{},"stale":false,"compatible":true,"compatibilityError":null,"logicalSessionTimeoutMinutes":null,"heartbeatFrequencyMS":10000,"localThresholdMS":15,"commonWireVersion":null}},"user":"testGaloy","address":"galoy-mongodb","db":"galoy","msg":"error connecting to mongodb"}


```