### PR TITLE
Reenabled persistence from dealer on testflight

### DIFF
--- a/ci/testflight/dealer/testflight-values.yml
+++ b/ci/testflight/dealer/testflight-values.yml
@@ -1,3 +1,0 @@
-postgresql:
-  persistence:
-    enabled: false


### PR DESCRIPTION
Empties out the testflight values file for dealer to reproduce same persistence issue on testflight.
Almost reverts https://github.com/GaloyMoney/charts/pull/229/files