### PR TITLE
Postgres chart disabled by default for dealer - enabled it for testflight and dev

### DIFF
--- a/charts/dealer/values.yaml
+++ b/charts/dealer/values.yaml
@@ -38,7 +38,7 @@ fakeGaloyApi:
     name: dealer-postgres
     key: postgresql-db-uri
 postgresql:
-  enabled: true
+  enabled: false
   postgresqlUsername: postgres
   existingSecret: dealer-postgres
   postgresqlDatabase: dealer

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -311,6 +311,7 @@ jobs:
           okex_secret: #@ data.values.staging_okex_secret
           okex_password: #@ data.values.staging_okex_password
           okex_fund_password: #@ data.values.staging_okex_fund_password
+          shared_pg_admin_password: #@data.values.staging_shared_pg_admin_password
   - in_parallel:
     #@ for chart in addons_charts:
     #@ if chart != "dealer":

--- a/ci/testflight/dealer/testflight-values.yml
+++ b/ci/testflight/dealer/testflight-values.yml
@@ -1,3 +1,4 @@
 postgresql:
+  enabled: true
   persistence:
     enabled: false

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -40,6 +40,7 @@ staging_okex_key: ((staging-okex.key))
 staging_okex_secret: ((staging-okex.secret))
 staging_okex_password: ((staging-okex.password))
 staging_okex_fund_password: ((staging-okex.fund_password))
+staging_shared_pg_admin_password: ((staging-shared-pg.password))
 
 galoy_slack_webhook_url: ((galoy-main-slack.api_url))
 monitoring_slack_webhook_url: ((monitoring-slack.api_url))

--- a/dev/addons/dealer-values.yml
+++ b/dev/addons/dealer-values.yml
@@ -1,0 +1,2 @@
+postgresql:
+  enabled: true

--- a/dev/addons/dealer.tf
+++ b/dev/addons/dealer.tf
@@ -39,6 +39,10 @@ resource "helm_release" "dealer" {
   repository = "https://galoymoney.github.io/charts"
   namespace  = kubernetes_namespace.addons.metadata[0].name
 
+  values = [
+    file("${path.module}/dealer-values.yml")
+  ]
+
   depends_on = [
     kubernetes_secret.postgres_creds,
     kubernetes_secret.okex5_creds


### PR DESCRIPTION
Also accommodates `pg-shared-admin-password` for staging ci pipeline.