### PR TITLE
Fix dealer staging pipeline

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -283,6 +283,7 @@ type: git
 source:
   uri: #@ data.values.git_org_uri + "/" + repo_name + ".git"
   private_key: #@ data.values.github_private_key
+  branch: main
 #@ end
 
 #@ def repo_resource_name(repo_name):

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -294,6 +294,7 @@ jobs:
             path: pipeline-tasks/ci/tasks/checkout-repo.sh
           params:
             CHART_SUBPATH: #@ "services/addons/vendor/" + chart
+            CHART: #@ chart
       - put: #@ repo_out_resource_name(chart)
         params:
           repository: repo
@@ -461,6 +462,7 @@ resources:
 - #@ repo_out_resource("galoy")
 - #@ repo_out_resource("admin-panel")
 - #@ repo_out_resource("galoy-pay")
+- #@ repo_out_resource("dealer")
 
 - #@ repo_resource("galoy")
 - #@ repo_resource("admin-panel")


### PR DESCRIPTION
This allows context based current head searching.
Hardcodes `branch: main` to repo resource name so not to share cache with it's `out` counterpart.