### PR TITLE
Drops dealer scraping twice

### DIFF
--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -308,6 +308,9 @@ prometheus:
             - source_labels: [__meta_kubernetes_pod_name]
               regex: 'lnd.*'
               action: drop
+            - source_labels: [__meta_kubernetes_pod_name]
+              regex: '*.dealer.*'
+              action: drop
 
         # - job_name: 'kubernetes-services'
 


### PR DESCRIPTION
Looks like the metrics are being scraped twice. `kubernetes-pods` task was dropped for lnd pods as well. Doing the same for dealer.

<img width="163" alt="Screenshot 2021-12-02 at 8 31 47 PM" src="https://user-images.githubusercontent.com/40622610/144447451-3a8626a4-9182-4cbe-a9e2-c01e1cde495b.png">
