### PR TITLE
feat: added kubemonkey labels for addons charts

### DIFF
--- a/charts/admin-panel/templates/deployment.yaml
+++ b/charts/admin-panel/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     app: {{ template "adminPanel.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+    {{- if .Values.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: {{ .Chart.Name }}
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +24,10 @@ spec:
       labels:
         app: {{ template "adminPanel.fullname" . }}
         release: "{{ .Release.Name }}"
+        {{- if .Values.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: {{ .Chart.Name }}
+        {{- end }}
 {{- with .Values.labels }}
 {{ toYaml . | trim | indent 8 }}
 {{- end }}

--- a/charts/admin-panel/values.yaml
+++ b/charts/admin-panel/values.yaml
@@ -7,3 +7,5 @@ ingress:
 service:
   port: 80
   type: ClusterIP
+kubemonkey:
+  enabled: true

--- a/charts/dealer/templates/dealer-deployment.yaml
+++ b/charts/dealer/templates/dealer-deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     app: {{ template "dealer.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+    {{- if .Values.dealer.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: {{ .Chart.Name }}
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +24,10 @@ spec:
       labels:
         app: {{ template "dealer.fullname" . }}
         release: "{{ .Release.Name }}"
+        {{- if .Values.dealer.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: {{ .Chart.Name }}
+        {{- end }}
       annotations:
         prometheus.io/path: {{ .Values.dealer.exporter.path }}
         prometheus.io/port: "{{ .Values.dealer.exporter.port }}"

--- a/charts/dealer/templates/fakegaloyapi-deployment.yaml
+++ b/charts/dealer/templates/fakegaloyapi-deployment.yaml
@@ -7,6 +7,13 @@ metadata:
     app: {{ .Values.fakeGaloyApi.name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+    {{- if .Values.fakeGaloyApi.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: fake-galoyapi
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +25,10 @@ spec:
       labels:
         app: {{ .Values.fakeGaloyApi.name }}
         release: "{{ .Release.Name }}"
+        {{- if .Values.fakeGaloyApi.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: fake-galoyapi
+        {{- end }}
     spec:
       containers:
       - name: graphql

--- a/charts/dealer/values.yaml
+++ b/charts/dealer/values.yaml
@@ -24,6 +24,8 @@ dealer:
       secret: okex5_secret
       password: okex5_password
       fundPassword: okex5_fund_password
+  kubemonkey:
+    enabled: true
 # === NOTE: Everything below this is for faking the graphql backend. ===
 fakeGaloyApi:
   enabled: true
@@ -38,6 +40,8 @@ fakeGaloyApi:
   dbSecretKeyRef:
     name: dealer-postgres
     key: postgresql-db-uri
+  kubemonkey:
+    enabled: true
 postgresql:
   enabled: false
   postgresqlUsername: postgres

--- a/charts/galoy-pay/templates/deployment.yaml
+++ b/charts/galoy-pay/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
     app: {{ template "galoyPay.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+    {{- if .Values.kubemonkey.enabled }}
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: {{ .Chart.Name }}
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +24,10 @@ spec:
       labels:
         app: {{ template "galoyPay.fullname" . }}
         release: "{{ .Release.Name }}"
+        {{- if .Values.kubemonkey.enabled }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: {{ .Chart.Name }}
+        {{- end }}
 {{- with .Values.labels }}
 {{ toYaml . | trim | indent 8 }}
 {{- end }}

--- a/charts/galoy-pay/values.yaml
+++ b/charts/galoy-pay/values.yaml
@@ -9,3 +9,5 @@ service:
   type: ClusterIP
 graphqlHostname: domain.example
 graphqlHostnameInternal: service-name.namespace.svc.cluster.local
+kubemonkey:
+  enabled: true


### PR DESCRIPTION
Adds Kube-Monkey labels for:
- `dealer`
- `admin-panel`
- `galoy-pay`