### PR TITLE
Flip depl-env to env-depl naming

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -198,7 +198,7 @@ source:
 #@ end
 
 #@ def cepler_resource_name(deployment):
-#@   return deployment + "-" + data.values.staging_environment
+#@   return data.values.staging_environment + "-" + deployment
 #@ end
 
 #@ def cepler_out_name(deployment):


### PR DESCRIPTION
This converts Concourse Resource names to `env-depl` because `gcp-galoy-staging-addons` make more sense than `addons-gcp-galoy-staging`.