### PR TITLE
Remove prometheus scrape annotations from lnd

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -16,11 +16,6 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
 
-podAnnotations:
-  prometheus.io/path: /metrics
-  prometheus.io/port: "9092"
-  prometheus.io/scrape: "true"
-
 terminationGracePeriodSeconds: 600
 
 resources:


### PR DESCRIPTION
We are using lndmon for scraping metrics, which it gets from scraping lnd. We don't need to scrape lnd directly via prometheus.