### PR TITLE
Revert "chore: modify galoy chart to use twilio auth token"

### DIFF
--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -224,11 +224,16 @@ spec:
                 secretKeyRef:
                   name: twilio-secret
                   key: TWILIO_ACCOUNT_SID
-            - name: TWILIO_AUTH_TOKEN
+            - name: TWILIO_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: twilio-secret
-                  key: TWILIO_AUTH_TOKEN
+                  key: TWILIO_API_KEY
+            - name: TWILIO_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: twilio-secret
+                  key: TWILIO_API_SECRET
             {{- end }}
           {{- if .healthz }}
           livenessProbe:

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -85,8 +85,9 @@ twilio: true
 # ie: helm upgrade -i --set twilio.TWILIO_PHONE_NUMBER=6505550001,TWILIO_ACCOUNT_SID=AKBQWN...
 # twilio:
 #   TWILIO_PHONE_NUMBER: "phone"
-#   TWILIO_ACCOUNT_SID: "sid"
-#   TWILIO_AUTH_TOKEN: "authtoken"
+#   TWILIO_ACCOUNT_SID: sid
+#   TWILIO_API_KEY: apikey
+#   TWILIO_API_SECRET: apisecret
 redis:
   master:
     persistence:

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -84,7 +84,8 @@ resource "kubernetes_secret" "twilio_secret" {
   data = {
     TWILIO_PHONE_NUMBER = ""
     TWILIO_ACCOUNT_SID  = ""
-    TWILIO_AUTH_TOKEN   = ""
+    TWILIO_API_KEY      = ""
+    TWILIO_API_SECRET   = ""
   }
 }
 

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -84,7 +84,8 @@ resource "kubernetes_secret" "twilio_secret" {
   data = {
     TWILIO_PHONE_NUMBER = ""
     TWILIO_ACCOUNT_SID  = ""
-    TWILIO_AUTH_TOKEN   = ""
+    TWILIO_API_KEY      = ""
+    TWILIO_API_SECRET   = ""
   }
 }
 


### PR DESCRIPTION
Reverts GaloyMoney/charts#399

Required to unblock `galoy-staging-galoy` pipeline, needs secret adition and when it's complete, will recreate this.