### PR TITLE
chore: modify galoy chart to use twilio auth token

### DIFF
--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -224,16 +224,11 @@ spec:
                 secretKeyRef:
                   name: twilio-secret
                   key: TWILIO_ACCOUNT_SID
-            - name: TWILIO_API_KEY
+            - name: TWILIO_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: twilio-secret
-                  key: TWILIO_API_KEY
-            - name: TWILIO_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: twilio-secret
-                  key: TWILIO_API_SECRET
+                  key: TWILIO_AUTH_TOKEN
             {{- end }}
           {{- if .healthz }}
           livenessProbe:

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -85,9 +85,8 @@ twilio: true
 # ie: helm upgrade -i --set twilio.TWILIO_PHONE_NUMBER=6505550001,TWILIO_ACCOUNT_SID=AKBQWN...
 # twilio:
 #   TWILIO_PHONE_NUMBER: "phone"
-#   TWILIO_ACCOUNT_SID: sid
-#   TWILIO_API_KEY: apikey
-#   TWILIO_API_SECRET: apisecret
+#   TWILIO_ACCOUNT_SID: "sid"
+#   TWILIO_AUTH_TOKEN: "authtoken"
 redis:
   master:
     persistence:

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -84,8 +84,7 @@ resource "kubernetes_secret" "twilio_secret" {
   data = {
     TWILIO_PHONE_NUMBER = ""
     TWILIO_ACCOUNT_SID  = ""
-    TWILIO_API_KEY      = ""
-    TWILIO_API_SECRET   = ""
+    TWILIO_AUTH_TOKEN   = ""
   }
 }
 

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -84,8 +84,7 @@ resource "kubernetes_secret" "twilio_secret" {
   data = {
     TWILIO_PHONE_NUMBER = ""
     TWILIO_ACCOUNT_SID  = ""
-    TWILIO_API_KEY      = ""
-    TWILIO_API_SECRET   = ""
+    TWILIO_AUTH_TOKEN   = ""
   }
 }
 


### PR DESCRIPTION
Redeploys https://github.com/GaloyMoney/charts/pull/399, coz it was reverted - now, should work at staging.