### PR TITLE
fix: Use exec for tor container

### DIFF
--- a/charts/lnd/templates/statefulset.yaml
+++ b/charts/lnd/templates/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
             CookieAuthFileGroupReadable 1
             $(cat ~/torrc)
             EOF
-            tor -f ~/torrc
+            exec tor -f ~/torrc
         - name: export-secrets
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ['/bin/sh']


### PR DESCRIPTION
Fixes #170 