### PR TITLE
feat: automatically migrate db pre-stratup

### DIFF
--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -28,6 +28,18 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      apiVersion: apps/v1
+      initContainers:
+      - name: wait-for-mongodb-migrate
+        image: "groundnuty/k8s-wait-for:1.5"
+        args:
+        - "job"
+        - "{{ .Release.Name }}-mongodb-migrate-{{ .Release.Revision }}"
+      containers:
+      # application container definitions
+      - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        # ...other container configuration
       containers:
         - name: {{ .name }}
           image: "{{ $.Values.image.repository }}@{{ $.Values.image.digest }}"

--- a/charts/galoy/templates/migration-job.yaml
+++ b/charts/galoy/templates/migration-job.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-mongodb-migrate-{{ .Release.Revision }}
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+      - name: mongodb-migrate
+        image: "{{ $.Values.mongodbMigrateImage.repository }}@{{ $.Values.mongodbMigrateImage.digest }}"
+        env:
+        - name: MONGODB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $.Release.Name }}-mongodb
+              key: "mongodb-password"
+        - name: MONGODB_USER
+          value: "testGaloy"
+        - name: MONGODB_ADDRESS
+          value: {{ $.Values.mongodbaddress }}
+      restartPolicy: never

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -15,6 +15,11 @@ image:
   repository: us.gcr.io/galoy-org/galoy-app
   digest: "sha256:de8fc8f506d79eb77e11ae6fb3a916c3e6bead406ac97e08b94c582029dc279b"
   git_ref: "c84829d" # Not used by helm
+
+mongodbMigrateImage:
+  repository: us.gcr.io/galoy-org/galoy-app-migrate
+  digest: "sha256:edc5321ef5951505e613cef59e8c10bc3e5a58b5c6d24c6eeb2a66004b487ca8"
+
 jaegerHost: localhost
 tracingPrefix: "galoy"
 deployment:


### PR DESCRIPTION
This PR adds a job that executes all database migrations and an init_container to the deployments of the galoy chart.

The init_container ensures that the new app code doesn't start until the migration has completed.