### PR TITLE
ci: ignore path Chart.yaml

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -168,6 +168,7 @@ source:
   paths:
   - #@ "charts/" + chart_name + "/*"
   - #@ "charts/" + chart_name + "/**/*"
+  - #@ "!charts/" + chart_name + "/Chart.yaml"
   - #@ "ci/tasks/" + chart_name + "-smoketest.sh"
   - #@ "ci/tasks/get-smoketest-settings.sh"
   uri: #@ data.values.git_uri


### PR DESCRIPTION
Updated on CI already.
To prevent cases like https://github.com/GaloyMoney/galoy-deployments/pull/992#issuecomment-1019309001