### PR TITLE
fix: no need for bodymindarts fork of k8s-wait-for

### DIFF
--- a/charts/galoy/templates/cronjob.yaml
+++ b/charts/galoy/templates/cronjob.yaml
@@ -15,13 +15,10 @@ spec:
           serviceAccountName: {{ $.Release.Name}}-serviceaccount
           initContainers:
           - name: wait-for-mongodb-migrate
-            image: "bodymindarts/k8s-wait-for:v1.5.1-fix"
+            image: "groundnuty/k8s-wait-for:v1.5.1"
             args:
-            - "job"
+            - "job-wr"
             - "{{ $.Release.Name }}-mongodb-migrate-{{ $.Release.Revision }}"
-            env:
-            - name: TREAT_ERRORS_AS_READY
-              value: "2"
           containers:
           - name: {{ .name }}
             image: "{{ $.Values.image.repository }}@{{ $.Values.image.digest }}"

--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -31,13 +31,10 @@ spec:
       serviceAccountName: {{ $.Release.Name}}-serviceaccount
       initContainers:
       - name: wait-for-mongodb-migrate
-        image: "bodymindarts/k8s-wait-for:v1.5.1-fix"
+        image: "groundnuty/k8s-wait-for:v1.5.1"
         args:
-        - "job"
+        - "job-wr"
         - "{{ $.Release.Name }}-mongodb-migrate-{{ $.Release.Revision }}"
-        env:
-        - name: TREAT_ERRORS_AS_READY
-          value: "2"
       containers:
         - name: {{ .name }}
           image: "{{ $.Values.image.repository }}@{{ $.Values.image.digest }}"

--- a/charts/galoy/templates/migration-job.yaml
+++ b/charts/galoy/templates/migration-job.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: {{ $.Release.Name}}-serviceaccount
       initContainers:
       - name: "trigger-mongodb-backup"
-        image: "bodymindarts/k8s-wait-for:v1.5.1-fix"
+        image: "groundnuty/k8s-wait-for:v1.5.1"
         command:
         - "/bin/sh"
         - "-c"


### PR DESCRIPTION
I found out that the fix isn't necessary and what we want is supported by adding the `-wr` postfix to the argument (see https://github.com/groundnuty/k8s-wait-for/blob/master/wait_for.sh#L234)