### PR TITLE
feat: add skip-proxy-for-clearnet-targets to lnd

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -97,6 +97,7 @@ lndGeneralConfig:
   - protocol.no-anchors=true
   - tor.active=true
   - tor.v3=true
+  - tor.skip-proxy-for-clearnet-targets=true
 
 bitcoindRpcPassSecretName: bitcoind-rpcpassword
 


### PR DESCRIPTION
Allow lnd to connect to non-onion services directly via clearnet (improve performance of probing and payments)
https://github.com/lightningnetwork/lnd/blob/master/sample-lnd.conf#L840