### PR TITLE
fix: force http1.1 for dropbox upload

### DIFF
--- a/charts/galoy/templates/mongo-backup-configmap.yaml
+++ b/charts/galoy/templates/mongo-backup-configmap.yaml
@@ -22,7 +22,7 @@ data:
     echo "Backing up mongodb"
     mongodump --host=$MONGODB_ADDRESS --port=$MONGODB_PORT --username=$MONGODB_USER --password=$MONGODB_PASSWORD --gzip --archive=$BACKUP_NAME -d=$MONGODB_DB --readPreference=secondary
     echo "Uploading backup $BACKUP_NAME to dropbox"
-    curl -X POST https://content.dropboxapi.com/2/files/upload --header "Authorization: Bearer $DROPBOX_ACCESS_TOKEN" --header "Dropbox-API-Arg: {\"path\": \"/mongo/$BACKUP_NAME\"}" --header "Content-Type: application/octet-stream" --data-binary $BACKUP_NAME
+    curl -X POST https://content.dropboxapi.com/2/files/upload --http1.1 --header "Authorization: Bearer $DROPBOX_ACCESS_TOKEN" --header "Dropbox-API-Arg: {\"path\": \"/mongo/$BACKUP_NAME\"}" --header "Content-Type: application/octet-stream" --data-binary $BACKUP_NAME
     echo "Uploading backup $BACKUP_NAME to gcs"
     gsutil cp $BACKUP_NAME gs://$BUCKET_NAME/$BACKUP_NAME 2>&1
     echo "Uploaded backup successfully"


### PR DESCRIPTION
Attempt to fix the error message on backup upload:
```
curl: (92) HTTP/2 stream 1 was not closed cleanly before end of the underlying stream
```

see https://stackoverflow.com/questions/56413290/getting-curl-92-http-2-stream-1-was-not-closed-cleanly-internal-error-err