### PR TITLE
chore: make coin selection random

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -98,6 +98,7 @@ lndGeneralConfig:
   - tor.active=true
   - tor.v3=true
   - tor.skip-proxy-for-clearnet-targets=true
+  - coin-selection-strategy=random
 
 bitcoindRpcPassSecretName: bitcoind-rpcpassword
 


### PR DESCRIPTION
this would be better than `largest` as this would limit the risk of too many unconfirmed transactions in the mempool