### PR TITLE
fix: remove random coin selection

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -94,7 +94,6 @@ lndGeneralConfig:
   - tor.active=true
   - tor.v3=true
   - tor.skip-proxy-for-clearnet-targets=true
-  - coin-selection-strategy=random
 bitcoindRpcPassSecretName: bitcoind-rpcpassword
 loop:
   enabled: true


### PR DESCRIPTION
this is increasing potential discrepency between the onchainFee calculation for fee check, and real fees being paid, because the UXTOs used would be different with a random selection. Without the random selection, the fees would likely be the same between the "feeProbe" and "realFee"