### PR TITLE
refactor: introduce top level webWallet key

### DIFF
--- a/charts/web-wallet/templates/deployment.yaml
+++ b/charts/web-wallet/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: web-wallet
-      {{- if eq .Values.useMobileLayout true }}
+      {{- if eq .Values.webWallet.useMobileLayout true }}
         image: "{{ .Values.mobileLayoutImage.repository }}@{{ .Values.mobileLayoutImage.digest }}"
       {{- else }}
         image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
@@ -42,27 +42,29 @@ spec:
           value: 0.0.0.0
         - name: PORT
           value: "3000"
+        - name: NETWORK
+          value: {{ .Values.webWallet.bitcoinNetwork }}
         - name: SUPPORT_EMAIL
-          value: {{ .Values.supportEmail }}
+          value: {{ .Values.webWallet.supportEmail }}
         - name: GRAPHQL_URI
-          value: {{ .Values.graphqlUri }}
+          value: {{ .Values.webWallet.graphqlUri }}
         - name: GRAPHQL_SUBSCRIPTION_URI
-          value: {{ .Values.graphqlSubscriptionUri }}
+          value: {{ .Values.webWallet.graphqlSubscriptionUri }}
         - name: AUTH_ENDPOINT
-          value: {{ .Values.authEndpoint }}
+          value: {{ .Values.webWallet.authEndpoint }}
         - name: WALLET_NAME
-          value: {{ .Values.walletName }}
+          value: {{ .Values.webWallet.walletName }}
         - name: WALLET_THEME
           value: default
         - name: SHARE_URI
-          value: {{ .Values.galoyPayEndpoint }}
-        {{- if eq .Values.kratos.enabled true }}
+          value: {{ .Values.webWallet.galoyPayEndpoint }}
+        {{- if eq .Values.webWallet.kratos.enabled true }}
         - name: KRATOS_API_URL
-          value: {{ .Values.kratos.api_url }}
+          value: {{ .Values.webWallet.kratos.api_url }}
         - name: KRATOS_BROWSER_URL
-          value: {{ .Values.kratos.browser_url }}
+          value: {{ .Values.webWallet.kratos.browser_url }}
         - name: KRATOS_AUTH_ENDPOINT
-          value: {{ .Values.kratos.auth_endpoint }}
+          value: {{ .Values.webWallet.kratos.auth_endpoint }}
         - name: KRATOS_FEATURE_FLAG
           value: "true"
         {{- end }}

--- a/charts/web-wallet/templates/deployment.yaml
+++ b/charts/web-wallet/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
     spec:
       containers:
       - name: web-wallet
-      {{- if eq .Values.webWallet.useMobileLayout true }}
-        image: "{{ .Values.mobileLayoutImage.repository }}@{{ .Values.mobileLayoutImage.digest }}"
+      {{- if eq .Values.mobileLayout.enabled true }}
+        image: "{{ .Values.mobileLayout.repository }}@{{ .Values.mobileLayout.digest }}"
       {{- else }}
         image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
       {{- end }}

--- a/charts/web-wallet/values.yaml
+++ b/charts/web-wallet/values.yaml
@@ -2,7 +2,8 @@ image:
   repository: us.gcr.io/galoy-org/web-wallet
   digest: "sha256:438220a9a01f0ce2ece49ae905bb073a5da43eef36cdbbeb5dfde6e9019d30c7"
   git_ref: "ec5dc40" # Not used by helm
-mobileLayoutImage:
+mobileLayout:
+  enabled: false
   repository: us.gcr.io/galoy-org/web-wallet-mobile-layout
   digest: "sha256:40e4edbd98cb3d58bda687265fbf0230c6c80745e69778db15218c287ee0e18f"
 ingress:
@@ -12,7 +13,6 @@ service:
   type: ClusterIP
 
 webWallet:
-  useMobileLayout: false
   bitcoinNetwork: regtest
   authEndpoint: api/login
   graphqlUri: http://localhost:4002/graphql

--- a/charts/web-wallet/values.yaml
+++ b/charts/web-wallet/values.yaml
@@ -5,18 +5,27 @@ image:
 mobileLayoutImage:
   repository: us.gcr.io/galoy-org/web-wallet-mobile-layout
   digest: "sha256:40e4edbd98cb3d58bda687265fbf0230c6c80745e69778db15218c287ee0e18f"
-useMobileLayout: false
 ingress:
   enabled: false
 service:
   port: 80
   type: ClusterIP
-authEndpoint: api/login
-graphqlUri: http://localhost:4002/graphql
-graphqlSubscriptionUri: wss://localhost:4002/graphql
-supportEmail: support@galoy.io
-walletName: galoy
-galoyPayEndpoint: http://localhost:4000
+
+webWallet:
+  useMobileLayout: false
+  bitcoinNetwork: regtest
+  authEndpoint: api/login
+  graphqlUri: http://localhost:4002/graphql
+  graphqlSubscriptionUri: wss://localhost:4002/graphql
+  supportEmail: support@galoy.io
+  walletName: galoy
+  galoyPayEndpoint: http://localhost:4000
+
+  kratos:
+    enabled: false
+    browser_url: http://localhost:4433
+    api_url: http://localhost:4433
+    auth_endpoint: http://localhost:4001/auth/browser
 secrets:
   ## Create the secret resource from the following values. Set this to
   ## false to manage these secrets outside Helm.
@@ -26,9 +35,3 @@ secrets:
   create: false
   ## cookieSession keys
   sessionKeys: "session-keys"
-
-kratos:
-  enabled: false
-  browser_url: http://localhost:4433
-  api_url: http://localhost:4433
-  auth_endpoint: http://localhost:4001/auth/browser

--- a/ci/testflight/web-wallet/web-wallet-mobile-testflight-values.yml
+++ b/ci/testflight/web-wallet/web-wallet-mobile-testflight-values.yml
@@ -1,1 +1,2 @@
-useMobileLayout: true
+mobileLayout:
+  enabled: true

--- a/dev/addons/web-wallet-mobile-values.yml
+++ b/dev/addons/web-wallet-mobile-values.yml
@@ -1,1 +1,2 @@
-useMobileLayout: false
+webWallet:
+  useMobileLayout: false

--- a/dev/addons/web-wallet-mobile-values.yml
+++ b/dev/addons/web-wallet-mobile-values.yml
@@ -1,2 +1,2 @@
-webWallet:
-  useMobileLayout: false
+mobileLayout
+  enabled: false


### PR DESCRIPTION
Let us start having a top level `<application>:` key to group the app specific settings instead of putting so many settings loosely on top level.