### PR TITLE
ci: automate version bumping for helm deps

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -194,8 +194,27 @@ jobs:
       inputs:
       - name: pipeline-tasks
       - name: charts-repo
+      outputs:
+      - name: charts-repo
       run:
         path: pipeline-tasks/ci/tasks/update-helm-deps.sh
+  - put: update-helm-deps-bot-branch
+    params:
+      repository: charts-repo
+      force: true
+  - task: open-bump-pr
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      params:
+        GH_TOKEN: #@ data.values.github_token
+        BRANCH: #@ data.values.git_branch
+        BOT_BRANCH: #@ data.values.git_update_helm_deps_bot_branch
+      inputs:
+      - name: pipeline-tasks
+      - name: charts-repo
+      run:
+        path: pipeline-tasks/ci/tasks/open-update-helm-deps-pr.sh
 
 resources:
 #@ for chart in bitcoin_charts:
@@ -283,6 +302,13 @@ resources:
   source:
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_lnd_sidecar_bot_branch
+    private_key: #@ data.values.github_private_key
+
+- name: update-helm-deps-bot-branch
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_update_helm_deps_bot_branch
     private_key: #@ data.values.github_private_key
 
 - name: one-day

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -179,6 +179,22 @@ jobs:
       run:
         path: pipeline-tasks/ci/tasks/open-lnd-sidecar-bump-pr.sh
 
+  - name: update-helm-deps
+    plan:
+    - in_parallel:
+      - get: 1d
+        trigger: true
+      - get: charts-repo
+    - task: update-helm-deps
+      config:
+        platform: linux
+        image_resource: #@ task_image_config()
+        inputs:
+        - name: pipeline-tasks
+        - name: charts-repo
+        run:
+          path: pipeline-tasks/ci/tasks/update-helm-deps.sh
+
 resources:
 #@ for chart in bitcoin_charts:
 - #@ chart_repo_resource(chart)
@@ -266,6 +282,11 @@ resources:
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_lnd_sidecar_bot_branch
     private_key: #@ data.values.github_private_key
+
+- name: 1d
+  type: time
+  source:
+    interval: 1d
 
 resource_types:
 - name: terraform

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -58,6 +58,7 @@ groups:
   - #@ testflight_job_name(chart)
   - #@ bump_in_deployments_job_name(chart)
 #@ end
+  - update-helm-deps
 - name: auth
   jobs:
   - galoy-auth-testflight
@@ -179,21 +180,22 @@ jobs:
       run:
         path: pipeline-tasks/ci/tasks/open-lnd-sidecar-bump-pr.sh
 
-  - name: update-helm-deps
-    plan:
-    - in_parallel:
-      - get: 1d
-        trigger: true
-      - get: charts-repo
-    - task: update-helm-deps
-      config:
-        platform: linux
-        image_resource: #@ task_image_config()
-        inputs:
-        - name: pipeline-tasks
-        - name: charts-repo
-        run:
-          path: pipeline-tasks/ci/tasks/update-helm-deps.sh
+- name: update-helm-deps
+  plan:
+  - in_parallel:
+    - get: one-day
+      trigger: true
+    - get: charts-repo
+    - get: pipeline-tasks
+  - task: update-helm-deps
+    config:
+      platform: linux
+      image_resource: #@ task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: charts-repo
+      run:
+        path: pipeline-tasks/ci/tasks/update-helm-deps.sh
 
 resources:
 #@ for chart in bitcoin_charts:
@@ -234,7 +236,7 @@ resources:
   source:
     paths: [ci/tasks/*, ci/testflight/*, Makefile]
     uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
+    branch: update-helm-deps
     private_key: #@ data.values.github_private_key
 
 - name: galoy-deployments
@@ -283,10 +285,10 @@ resources:
     branch: #@ data.values.git_lnd_sidecar_bot_branch
     private_key: #@ data.values.github_private_key
 
-- name: 1d
+- name: one-day
   type: time
   source:
-    interval: 1d
+    interval: 24h
 
 resource_types:
 - name: terraform

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -255,7 +255,7 @@ resources:
   source:
     paths: [ci/tasks/*, ci/testflight/*, Makefile]
     uri: #@ data.values.git_uri
-    branch: update-helm-deps
+    branch: #@ data.values.git_branch
     private_key: #@ data.values.github_private_key
 
 - name: galoy-deployments

--- a/ci/tasks/open-update-helm-deps-pr.sh
+++ b/ci/tasks/open-update-helm-deps-pr.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+pushd charts-repo
+
+cat <<EOF >> ../body.md
+This PR updates Helm Chart Dependencies.
+EOF
+
+gh pr close ${BOT_BRANCH} || true
+gh pr create \
+  --title "chore(deps): update helm chart dependencies" \
+  --body-file ../body.md \
+  --base ${BRANCH} \
+  --head ${BOT_BRANCH} \
+  --label galoybot \
+  --label helm

--- a/ci/tasks/update-helm-deps.sh
+++ b/ci/tasks/update-helm-deps.sh
@@ -40,3 +40,18 @@ for d in */ ; do
   popd
 
 done
+
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "bot@galoy.io"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "CI Bot"
+fi
+
+
+(cd $(git rev-parse --show-toplevel)
+git merge --no-edit ${BRANCH}
+git add -A
+git status
+git commit -m "chore(deps): update helm chart dependencies"
+)

--- a/ci/tasks/update-helm-deps.sh
+++ b/ci/tasks/update-helm-deps.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+cd charts-repo/charts
+
+for d in */ ; do
+
+  pushd $d
+
+  DEPS=$(helm dependency list | tail -n +2 | grep -v WARNING | xargs -n 4)
+
+  TMPFILE=$(mktemp /tmp/helm-update.XXXXXXX) || exit 1
+
+  echo $DEPS | xargs -n 4 | awk '{ print $1,$3 }' > $TMPFILE
+
+  if [[ $(cat $TMPFILE | grep \\.) == "" ]]; then
+    popd
+    continue
+  fi
+
+  L=0
+  while IFS="" read -r p || [ -n "$p" ]
+  do
+    dep=$(echo $p | cut -d' ' -f1)
+    repo=$(echo $p | cut -d' ' -f2)
+
+    helm repo add repository $repo
+
+    VERSION=$(helm search repo repository/$dep -o json | jq -r '[.[]][0] | .version')
+    yq -i ".dependencies[$L].version = \"$VERSION\"" Chart.yaml
+
+    helm repo remove repository
+
+    L=$((L+1))
+  done < $TMPFILE
+
+  rm $TMPFILE
+
+  helm dependency update
+
+  popd
+
+done

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -3,6 +3,7 @@
 deployments_git_uri: git@github.com:GaloyMoney/galoy-deployments.git
 deployments_git_branch: main
 git_lnd_sidecar_bot_branch: bot-bump-lnd-sidecar-image
+git_update_helm_deps_bot_branch: bot-update-helm-deps
 git_org_uri: git@github.com:GaloyMoney
 git_uri: git@github.com:GaloyMoney/charts.git
 git_branch: main


### PR DESCRIPTION
Adds a CI task that checks for a newer dependency version for all of our Helm Charts and creates a PR to update them.
Example PR: https://github.com/GaloyMoney/charts/pull/770