### PR TITLE
fix: add postgres as dependency to galoy chart

### DIFF
--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.8.0
-digest: sha256:f1b8ca781e47b5dfba2ed9e1755a6d40b5edba47806ed0f7f71af43422129145
-generated: "2021-12-16T19:21:21.156660878+05:30"
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.1.9
+digest: sha256:d4becc0afc07657d31d8c9b9a0005e6dd566b966227b7c13105a8920ddb33803
+generated: "2022-03-31T16:51:00.911610205+05:30"

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
   - name: common
     version: 1.8.0
     repository: https://charts.bitnami.com/bitnami
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.1.9
+    condition: price.postgresql.enabled

--- a/dev/galoy/galoy-values.yml
+++ b/dev/galoy/galoy-values.yml
@@ -56,9 +56,6 @@ cron: []
 twilio: false
 
 price:
-  postgresql:
-    auth:
-      enablePostgresUser: false
   service:
     type: NodePort
 


### PR DESCRIPTION
It looks like the right way to render nested dependencies is to declare them in the top level chart's dependencies. Without this,  helm will silently ignore the nested dependency, which is what we were experiencing on the price chart's testflight.

We can still conditionally render it by using the correct scoping in the `condition` block.