### PR TITLE
fix: new js cmd filename

### DIFF
--- a/charts/dealer/templates/dealer-deployment.yaml
+++ b/charts/dealer/templates/dealer-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         args:
         - "-r"
         - "/app/dealer/lib/services/tracing.js"
-        - "/app/dealer/lib/app/scheduler.js"
+        - "/app/dealer/lib/app/start.js"
         env:
         - name: NETWORK
           value: {{ .Values.dealer.network }}


### PR DESCRIPTION
The dealer docker file entrypoint/cmd was changed in a previous pr, but deployment template was not updated.