### PR TITLE
feat: array input for lnd values in ride the lightning config

### DIFF
--- a/charts/rtl/templates/configmap_and_secret.yaml
+++ b/charts/rtl/templates/configmap_and_secret.yaml
@@ -18,40 +18,28 @@ data:
         "logoutRedirectLink": "/login"
       },
       "nodes": [
+        {{- $c := 0 | int }}
+        {{- range .Values.lnds }}
+        {{- $c = add1 $c }}
         {
-          "index": 1,
-          "lnNode": "Node 1",
+          "index": {{ $c }},
+          "lnNode": "Node {{ $c }}",
           "lnImplementation": "LND",
           "Authentication": {
-            "macaroonPath": "/lnd1/rpc",
+            "macaroonPath": "/lnd{{ $c }}/rpc",
             "configPath": ""
           },
           "Settings": {
             "userPersona": "OPERATOR",
-            "themeMode": "DAY",
-            "themeColor": "PURPLE",
-            "lnServerUrl": "https://{{.Values.lnd1Url}}:8080",
+            "themeMode": {{ if .dark }}"NIGHT"{{ else }}"DAY"{{ end }},
+            "themeColor": "{{ .themeColor }}",
+            "lnServerUrl": "https://{{ .url }}:8080",
             "enableLogging": true,
-            "fiatConversion": true
+            "fiatConversion": true,
+            "channelBackupPath": "/home/node/node{{ $c }}backup"
           }
-        },
-        {
-          "index": 2,
-          "lnNode": "Node 2",
-          "lnImplementation": "LND",
-          "Authentication": {
-            "macaroonPath": "/lnd2/rpc",
-            "configPath": ""
-          },
-          "Settings": {
-            "userPersona": "OPERATOR",
-            "themeMode": "DAY",
-            "themeColor": "PURPLE",
-            "lnServerUrl": "https://{{.Values.lnd2Url}}:8080",
-            "enableLogging": true,
-            "fiatConversion": true
-          }
-        }
+        }{{- if ne (len $.Values.lnds) $c}},{{ end }}
+        {{- end }}
       ]
     }
 ---

--- a/charts/rtl/templates/deployment.yaml
+++ b/charts/rtl/templates/deployment.yaml
@@ -56,26 +56,23 @@ spec:
             - name: rtl-conf
               mountPath: "/RTL/RTL-Config.json"
               subPath: "RTL-Config.json"
-              # readOnly: true
-            - name: lnd1-rpc
-              mountPath: /lnd1/rpc
-              readOnly: true
-            {{- if .Values.lnd2SecretName -}}
-            - name: lnd2-rpc
-              mountPath: /lnd2/rpc
+            {{- $c := 0 | int }}
+            {{- range .Values.lnds }}
+            {{- $c = add1 $c }}
+            - name: "lnd{{ $c }}-rpc"
+              mountPath: "/lnd{{ $c }}/rpc"
               readOnly: true
             {{- end }}
       volumes:
           - name: rtl-conf
             configMap:
               name: {{ include "rtl.fullname" . }}
-          - name: lnd1-rpc
+          {{- $c := 0 | int }}
+          {{- range .Values.lnds }}
+          {{- $c = add1 $c }}
+          - name: lnd{{ $c }}-rpc
             secret:
-              secretName: {{ .Values.lnd1SecretName }}
-          {{- if .Values.lnd2SecretName -}}
-          - name: lnd2-rpc
-            secret:
-              secretName: {{ .Values.lnd2SecretName }}
+              secretName: {{ .secretName }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/rtl/values.yaml
+++ b/charts/rtl/values.yaml
@@ -32,9 +32,11 @@ service:
   port: 3000
   type: ClusterIP
 
-# FIXME: Intake an array of lnds and secret names
-lnd1Url: lnd1
-lnd1SecretName: lnd1-credentials
+lnds:
+  - url: lnd1
+    secretName: lnd1-credentials
+    dark: true
+    themeColor: YELLOW
 
 resources: {}
 


### PR DESCRIPTION
This PR changes the configuration map to iterate over an array of lnd values. I have also added the possibility to enable dark mode and themes.
I've also set the channelBackupPath to a place where the rtl process has write access - else you get error messages with each channel open or close.

**!This changes the values structure!**
Here is an example for two lnds in the new format:
```
lnds:
  - url: lnd1
    secretName: lnd1-credentials
    dark: true
    themeColor: YELLOW
  - url: lnd2
    secretName: lnd2-credentials
    dark: false
    themeColor: BLUE
```
The possible values for themeColor are:  BLUE GREEN INDIGO PINK PURPLE TEAL YELLOW

UPDATE: Updated to match new naming convention.