### PR TITLE
chore(deps): bump lnd in sidecar image

### DIFF
--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM lightninglabs/lnd:v0.14.2-beta as lnd
+FROM lightninglabs/lnd:v0.14.3-beta as lnd
 
 FROM alpine/k8s:1.21.5
 


### PR DESCRIPTION
The sidecar image needs to be updated now that we are using LND `0.14.3-beta`