### PR TITLE
ci: genericize image build and bump tasks

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,15 +151,20 @@ jobs:
       image_resource: #@ task_image_config()
       inputs:
       - name: lnd-sidecar-image
+        path: image
       - name: lnd-sidecar-image-def
+        path: image-def
       - name: pipeline-tasks
       - name: charts-repo
       outputs:
       - name: charts-repo
       params:
         BRANCH: #@ data.values.git_branch
+        IMAGE_KEY_PATH: sidecarImage
+        IMAGE: lnd-sidecar
+        CHART: lnd
       run:
-        path: pipeline-tasks/ci/tasks/bump-lnd-sidecar-image-digest.sh
+        path: pipeline-tasks/ci/tasks/bump-image-digest.sh
   - put: lnd-sidecar-bot-branch
     params:
       repository: charts-repo
@@ -171,13 +176,17 @@ jobs:
       inputs:
       - name: pipeline-tasks
       - name: lnd-sidecar-image
+        path: image
       - name: charts-repo
       params:
         GH_TOKEN: #@ data.values.github_token
         BRANCH: #@ data.values.git_branch
         BOT_BRANCH: #@ data.values.git_lnd_sidecar_bot_branch
+        IMAGE_KEY_PATH: sidecarImage
+        IMAGE: lnd-sidecar
+        CHART: lnd
       run:
-        path: pipeline-tasks/ci/tasks/open-lnd-sidecar-bump-pr.sh
+        path: pipeline-tasks/ci/tasks/open-image-bump-pr.sh
 
 resources:
 #@ for chart in bitcoin_charts:

--- a/ci/tasks/bump-image-digest.sh
+++ b/ci/tasks/bump-image-digest.sh
@@ -2,13 +2,13 @@
 
 set -eu
 
-export digest=$(cat ./lnd-sidecar-image/digest)
-export ref=$(cat ./lnd-sidecar-image-def/.git/short_ref)
+export digest=$(cat ./image/digest)
+export ref=$(cat ./image-def/.git/short_ref)
 
 pushd charts-repo
 
-yq -i e '.sidecarImage.digest = strenv(digest)' ./charts/lnd/values.yaml
-yq -i e '.sidecarImage.git_ref = strenv(ref)' ./charts/lnd/values.yaml
+yq -i e '.${IMAGE_KEY_PATH}.digest = strenv(digest)' ./charts/${CHART}/values.yaml
+yq -i e '.${IMAGE_KEY_PATH}.git_ref = strenv(ref)' ./charts/${CHART}/values.yaml
 
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@galoy.io"
@@ -22,5 +22,5 @@ fi
   git merge --no-edit ${BRANCH}
   git add -A
   git status
-  git commit -m "chore(deps): bump lnd sidecar image to '${digest}'"
+  git commit -m "chore(deps): bump ${IMAGE} image to '${digest}'"
 )

--- a/ci/tasks/open-image-bump-pr.sh
+++ b/ci/tasks/open-image-bump-pr.sh
@@ -2,18 +2,18 @@
 
 set -eu
 
-digest=$(cat ./lnd-sidecar-image/digest)
+digest=$(cat ./image/digest)
 
 pushd charts-repo
 
-ref=$(yq e '.sidecarImage.git_ref' charts/lnd/values.yaml)
+ref=$(yq e '.${IMAGE_KEY_PATH}.git_ref' charts/${CHART}/values.yaml)
 git checkout ${BRANCH}
-old_ref=$(yq e '.sidecarImage.git_ref' charts/lnd/values.yaml)
+old_ref=$(yq e '.${IMAGE_KEY_PATH}.git_ref' charts/${CHART}/values.yaml)
 
 cat <<EOF >> ../body.md
-# Bump lnd sidecar image
+# Bump ${IMAGE} image
 
-The lnd sidecar image will be bumped to digest:
+The ${IMAGE} image will be bumped to digest:
 \`\`\`
 ${digest}
 \`\`\`
@@ -25,9 +25,9 @@ EOF
 
 gh pr close ${BOT_BRANCH} || true
 gh pr create \
-  --title "chore(deps): bump-lnd-sidecar-image-${ref}" \
+  --title "chore(deps): bump-${IMAGE}-image-${ref}" \
   --body-file ../body.md \
   --base ${BRANCH} \
   --head ${BOT_BRANCH} \
   --label galoybot \
-  --label lnd
+  --label ${CHART}


### PR DESCRIPTION
This PR will genericize the image building tasks, allowing them to be reused for other builds like the mongo backup image