### PR TITLE
refactor: remove network from lnd customValues

### DIFF
--- a/charts/lnd/templates/configmap.yaml
+++ b/charts/lnd/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
     wallet-unlock-password-file=/tmp/lnd-pass
     wallet-unlock-allow-create=true
   {{- end }}
+    bitcoin.{{ .Values.global.network }}=true
   {{- range .Values.lndGeneralConfig }}
     {{ . }}
   {{- end }}

--- a/charts/lnd/templates/configmap.yaml
+++ b/charts/lnd/templates/configmap.yaml
@@ -10,7 +10,6 @@ data:
     wallet-unlock-password-file=/tmp/lnd-pass
     wallet-unlock-allow-create=true
   {{- end }}
-    bitcoin.{{ .Values.global.network }}=true
   {{- range .Values.lndGeneralConfig }}
     {{ . }}
   {{- end }}
@@ -25,3 +24,4 @@ data:
     tlsextraip={{ .Values.p2pService.staticIP }}
     externalip={{ .Values.p2pService.staticIP }}
   {{- end}}
+    bitcoin.{{ .Values.global.network }}=true

--- a/ci/testflight/lnd/testflight-values.yml
+++ b/ci/testflight/lnd/testflight-values.yml
@@ -18,7 +18,6 @@ persistence:
 
 configmap:
   customValues:
-    - bitcoin.testnet=true
     - bitcoind.rpchost=bitcoind.galoy-staging-bitcoin.svc.cluster.local:18332
     - bitcoind.zmqpubrawblock=tcp://bitcoind.galoy-staging-bitcoin.svc.cluster.local:28332
     - bitcoind.zmqpubrawtx=tcp://bitcoind.galoy-staging-bitcoin.svc.cluster.local:28333


### PR DESCRIPTION
Removes network pinning on customValues requirement in lnd config. Sets from `global.network`.