### PR TITLE
feat!: reintroduce ingress config for kubernetes >=v1.22 

### DIFF
--- a/charts/bitcoind/templates/ingress.yaml
+++ b/charts/bitcoind/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "bitcoind.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/galoy/charts/price/templates/ingress.yaml
+++ b/charts/galoy/charts/price/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "price.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/galoy/templates/admin-ingress.yaml
+++ b/charts/galoy/templates/admin-ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.adminIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.adminIngress.name }}
@@ -22,7 +22,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: graphql-admin
-          servicePort: 4001
+          service:
+            name: graphql-admin
+            port:
+              number: 4001
 {{ end }}

--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.apiIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.apiIngress.name }}
@@ -26,7 +26,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: api
-          servicePort: 4002
+          service:
+            name: api
+            port:
+              number: 4002
 {{ end }}

--- a/charts/lnd/charts/lndmon/templates/ingress.yaml
+++ b/charts/lnd/charts/lndmon/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "lndmon.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/specter/templates/ingress.yaml
+++ b/charts/specter/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "specter.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/dev/addons/dealer.tf
+++ b/dev/addons/dealer.tf
@@ -5,6 +5,8 @@ locals {
   okex5_secret        = "secret"
   okex5_password      = "pwd"
   okex5_fund_password = "none"
+  phone               = "dealerphone"
+  code                = "dealercode"
 }
 
 resource "kubernetes_secret" "okex5_creds" {
@@ -30,6 +32,18 @@ resource "kubernetes_secret" "postgres_creds" {
   data = {
     "postgresql-password" : local.postgres_password
     "postgresql-db-uri" : local.postgres_db_uri
+  }
+}
+
+resource "kubernetes_secret" "dealer_creds" {
+  metadata {
+    name      = "dealer-creds"
+    namespace = kubernetes_namespace.addons.metadata[0].name
+  }
+
+  data = {
+    "phone" : local.phone
+    "code" : local.code
   }
 }
 

--- a/dev/addons/web-wallet-mobile-values.yml
+++ b/dev/addons/web-wallet-mobile-values.yml
@@ -1,2 +1,2 @@
 mobileLayout:
-  enabled: false
+  enabled: true

--- a/dev/addons/web-wallet.tf
+++ b/dev/addons/web-wallet.tf
@@ -13,12 +13,31 @@ resource "kubernetes_secret" "web_wallet_secret" {
   }
 }
 
+resource "kubernetes_secret" "web_wallet_mobile_secret" {
+  metadata {
+    name      = "web-wallet-mobile"
+    namespace = kubernetes_namespace.addons.metadata[0].name
+  }
+
+  data = {
+    "session-keys" : local.session_keys
+  }
+}
+
 resource "helm_release" "web_wallet" {
   name      = "web-wallet"
   chart     = "${path.module}/../../charts/web-wallet"
   namespace = kubernetes_namespace.addons.metadata[0].name
 
   depends_on = [kubernetes_secret.web_wallet_secret]
+}
+
+resource "helm_release" "web_wallet_mobile" {
+  name      = "web-wallet-mobile"
+  chart     = "${path.module}/../../charts/web-wallet"
+  namespace = kubernetes_namespace.addons.metadata[0].name
+
+  depends_on = [kubernetes_secret.web_wallet_mobile_secret]
 
   values = [
     file("${path.module}/web-wallet-mobile-values.yml")

--- a/dev/addons/web-wallet.tf
+++ b/dev/addons/web-wallet.tf
@@ -19,14 +19,6 @@ resource "helm_release" "web_wallet" {
   namespace = kubernetes_namespace.addons.metadata[0].name
 
   depends_on = [kubernetes_secret.web_wallet_secret]
-}
-
-resource "helm_release" "web_wallet_mobile_layout" {
-  name      = "web-wallet"
-  chart     = "${path.module}/../../charts/web-wallet"
-  namespace = kubernetes_namespace.addons.metadata[0].name
-
-  depends_on = [kubernetes_secret.web_wallet_secret]
 
   values = [
     file("${path.module}/web-wallet-mobile-values.yml")

--- a/dev/bitcoin/lnd1.tf
+++ b/dev/bitcoin/lnd1.tf
@@ -16,7 +16,7 @@ resource "helm_release" "lnd" {
   namespace = kubernetes_namespace.bitcoin.metadata[0].name
 
   dependency_update = true
-
+  timeout = 600
   values = [
     file("${path.module}/lnd-values.yml")
   ]


### PR DESCRIPTION
Proposing again as it was merged before:  #1101, but was reverted in #1114  because the galoy-smoketest on staging failed after the last merge which can be related to the testnet blockstorm at the time as well.

The changes are compatible with kubernetes > 1.19, but needed to run the new installs using >1.22

There are some small fixes also affecting only the dev environment.

Tests were successful locally.