### PR TITLE
chore: update loop to v0.19.1-beta

### DIFF
--- a/charts/lnd/charts/loop/values.yaml
+++ b/charts/lnd/charts/loop/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: lightninglabs/loopserver
-  tag: latest
+  repository: lightninglabs/loop
+  tag: v0.19.1-beta
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
overrides #1197 using the correct image for the loop client