### PR TITLE
chore: remove sync-freelist setting to use default

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -80,7 +80,6 @@ lndGeneralConfig:
   - tlsextradomain=lnd
   - accept-keysend=1
   - allow-circular-route=1
-  - sync-freelist=1
   - stagger-initial-reconnect=1
   - protocol.wumbo-channels=1
   - maxchansize=500000000


### PR DESCRIPTION
Having the sync-freelist=1 :

>will decrease
start up time, but can result in performance degradation for very large
databases, and also result in higher memory usage.

https://github.com/lightningnetwork/lnd/blob/fec8fd9c63dc672dc3ea1b9be47bd1d6c4a0a54d/sample-lnd.conf#L89

>you'll see very high CPU usage with large database, since it needs to sort+write the freelist to disk each time. The default setting trades that off for longer start times, since the freelist needs to be reconstructed at start up each time.

https://github.com/lightningnetwork/lnd/issues/6737#issuecomment-1195726285

This PR will switch it off everywhere as it is not specified for the individual deployments.