### PR TITLE
fix: disable pg persistence on dealer testflight

### DIFF
--- a/ci/testflight/dealer/testflight-values.yml
+++ b/ci/testflight/dealer/testflight-values.yml
@@ -1,4 +1,5 @@
 postgresql:
   enabled: true
-  persistence:
-    enabled: false
+  primary:
+    persistence:
+      enabled: false


### PR DESCRIPTION
The postgresql chart was refactored and thus the key for persistence was moved under a new `primary` key. This PR should bring our testflight-values.yml in line with what the latest chart expects.