### PR TITLE
feat: add loopout automation config to the loop chart

### DIFF
--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -95,11 +95,6 @@ spec:
                 secretKeyRef:
                   name: lnd1-credentials
                   key: admin_macaroon_base64
-            - name: LND1_LOOP_MACAROON
-              valueFrom:
-                secretKeyRef:
-                  name: lnd1-loop-credentials
-                  key: loop_macaroon_base64
             - name: LND1_TLS
               valueFrom:
                 secretKeyRef:
@@ -110,11 +105,6 @@ spec:
                 secretKeyRef:
                   name: lnd1-pubkey
                   key: pubkey
-            - name: LND1_LOOP_TLS
-              valueFrom:
-                secretKeyRef:
-                  name: lnd1-loop-credentials
-                  key: tls_base64
 
             - name: LND2_DNS
               value: {{ $.Values.lnd2.dns }}
@@ -123,11 +113,6 @@ spec:
                 secretKeyRef:
                   name: lnd2-credentials
                   key: admin_macaroon_base64
-            - name: LND2_LOOP_MACAROON
-              valueFrom:
-                secretKeyRef:
-                  name: lnd2-loop-credentials
-                  key: loop_macaroon_base64
             - name: LND2_TLS
               valueFrom:
                 secretKeyRef:
@@ -138,11 +123,6 @@ spec:
                 secretKeyRef:
                   name: lnd2-pubkey
                   key: pubkey
-            - name: LND2_LOOP_TLS
-              valueFrom:
-                secretKeyRef:
-                  name: lnd2-loop-credentials
-                  key: tls_base64
 
             - name: BITCOINDADDR
               value: {{ $.Values.bitcoind.address }}

--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -95,6 +95,11 @@ spec:
                 secretKeyRef:
                   name: lnd1-credentials
                   key: admin_macaroon_base64
+            - name: LND1_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND1_TLS
               valueFrom:
                 secretKeyRef:
@@ -105,6 +110,11 @@ spec:
                 secretKeyRef:
                   name: lnd1-pubkey
                   key: pubkey
+            - name: LND1_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: tls_base64
 
             - name: LND2_DNS
               value: {{ $.Values.lnd2.dns }}
@@ -113,6 +123,11 @@ spec:
                 secretKeyRef:
                   name: lnd2-credentials
                   key: admin_macaroon_base64
+            - name: LND2_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND2_TLS
               valueFrom:
                 secretKeyRef:
@@ -123,6 +138,11 @@ spec:
                 secretKeyRef:
                   name: lnd2-pubkey
                   key: pubkey
+            - name: LND2_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: tls_base64
 
             - name: BITCOINDADDR
               value: {{ $.Values.bitcoind.address }}

--- a/charts/lnd/charts/loop/templates/export-secrets-configmap.yaml
+++ b/charts/lnd/charts/loop/templates/export-secrets-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-export-loop-secrets" (include "lnd.fullname" .) }}
+  labels:
+    {{- include "lnd.labels" . | nindent 4 }}
+data:
+  exportSecrets.sh: |
+    #!/bin/sh
+
+    export TLS=$(base64 /root/.loop/$NETWORK/tls.cert | tr -d '\n\r')
+    export MACAROON=$(base64 /root/.loop/$NETWORK/loop.macaroon | tr -d '\n\r')
+
+    mkdir macaroons
+    cp /root/.loop/$NETWORK/*.macaroon macaroons
+
+    kubectl create secret generic {{ include "lnd.fullname" . }}-loop-credentials \
+    --from-literal=tls_base64=$TLS --from-file=/root/.loop/$NETWORK/tls.cert \
+    --from-literal=loop_macaroon_base64=$MACAROON --from-file=macaroons \
+    --dry-run=client -o yaml | kubectl apply -f -

--- a/charts/lnd/charts/loop/templates/service.yaml
+++ b/charts/lnd/charts/loop/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: rest
+    - port: {{ .Values.loop.ports.grpc }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     {{- include "loop.selectorLabels" . | nindent 4 }}

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -36,7 +36,8 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           command: [
-            "/bin/sh -c",
+            "/bin/sh",
+            "-c",
             "loopd",
             "--lnd.host={{ .Release.Name }}:10009",
             "--network {{.Values.global.network}}",

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -35,7 +35,14 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command: ["/bin/sh","-c", "loopd --lnd.host={{ .Release.Name }}:10009 --network {{.Values.global.network}}"]
+          command: [
+            "/bin/sh -c",
+            "loopd",
+            "--lnd.host={{ .Release.Name }}:10009",
+            "--network {{.Values.global.network}}",
+            "--restlisten=0.0.0.0:{{.Values.loop.ports.rest}}",
+            "--rpclisten=0.0.0.0:{{.Values.loop.ports.grpc}}"
+          ]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -69,6 +76,31 @@ spec:
               mountPath: "/root/.lnd/data/chain/bitcoin/{{.Values.global.network}}/"
             - name: loop-storage
               mountPath: /root/.loop
+        - name: export-secrets
+          image: "{{ .Values.sidecarImage.repository }}@{{ .Values.sidecarImage.digest }}"
+          command: ['/bin/sh']
+          args:
+          - '-c'
+          - |
+            lncli -n=$NETWORK getinfo
+            while [[ $? != 0 ]]; do sleep 1; lncli -n=$NETWORK getinfo; done
+            /home/alpine/exportSecrets.sh
+            trap "echo shutting down; exit 0" SIGKILL SIGTERM
+            while true; do sleep 1; done
+          env:
+          - name: NETWORK
+            valueFrom:
+              secretKeyRef:
+                name: network
+                key: network
+          volumeMounts:
+          - name: export-secrets
+            mountPath: /home/alpine/exportSecrets.sh
+            subPath: exportSecrets.sh
+          - name: lnd-storage
+            mountPath: /root/.lnd
+          - name: loop-storage
+            mountPath: /root/.loop
       volumes:
       - name: lnd-tls
         secret:
@@ -79,6 +111,10 @@ spec:
       - name: lnd-macaroons
         secret:
           secretName: {{.Release.Name}}-credentials
+      - name: export-secrets
+          configMap:
+            name: {{ printf "%s-export-secrets" (include "lnd.fullname" .) }}
+            defaultMode: 0777
       - name: loop-storage
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -82,8 +82,8 @@ spec:
           args:
           - '-c'
           - |
-            lncli -n=$NETWORK getinfo
-            while [[ $? != 0 ]]; do sleep 1; lncli -n=$NETWORK getinfo; done
+            loop -n $NETWORK terms
+            while [[ $? != 0 ]]; do sleep 1; loop -n $NETWORK terms; done
             /home/alpine/exportSecrets.sh
             trap "echo shutting down; exit 0" SIGKILL SIGTERM
             while true; do sleep 1; done

--- a/charts/lnd/charts/loop/values.yaml
+++ b/charts/lnd/charts/loop/values.yaml
@@ -7,6 +7,11 @@ image:
   tag: v0.19.1-beta
   pullPolicy: IfNotPresent
 
+loop:
+  ports:
+    rest: 8081
+    grpc: 11010
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,8 +1,10 @@
 FROM lightninglabs/lnd:v0.15.0-beta as lnd
+FROM lightninglabs/loop:v0.19.1-beta as loop
 
 FROM alpine/k8s:1.21.5
 
 COPY --from=lnd /bin/lncli /bin/lncli
+COPY --from=loop /bin/loop /bin/loop
 
 RUN apk --update add expect curl jq
 


### PR DESCRIPTION
This PR adds config for loopout automation. See https://github.com/GaloyMoney/galoy/pull/1396 

The loop service has its own `loop.macaroon` and tls cert that the `main galoy backend` needs to talk to the loop grpc endpoint. This PR adds the secrets and config. 