### PR TITLE
fix: run galoy-testflight with injected redis password

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -221,6 +221,22 @@ resource "kubernetes_secret" "price_history_postgres_creds" {
   }
 }
 
+resource "random_password" "redis" {
+  length  = 20
+  special = false
+}
+
+resource "kubernetes_secret" "redis_password" {
+  metadata {
+    name      = "galoy-redis"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = {
+    "redis-password" : random_password.redis.result
+  }
+}
+
 resource "helm_release" "galoy" {
   name       = "galoy"
   chart      = "${path.module}/chart"

--- a/ci/testflight/galoy/testflight-values.yml
+++ b/ci/testflight/galoy/testflight-values.yml
@@ -58,3 +58,8 @@ price:
     primary:
       persistence:
         enabled: false
+
+redis:
+  auth:
+    existingSecret: "galoy-redis"
+    existingSecretPasswordKey: "redis-password"


### PR DESCRIPTION
Test improved security of running redis with injected password (instead of default).