### PR TITLE
feat: initial stablesats chart (price-server)

### DIFF
--- a/charts/galoy-auth/templates/_helpers.tpl
+++ b/charts/galoy-auth/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "galoyAuth.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/galoy-auth/templates/ingress.yaml
+++ b/charts/galoy-auth/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "galoyAuth.fullname" . }}
+  labels:
+    app: {{ include "galoyAuth.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
+spec:
+  rules:
+    {{- if .Values.ingress.rulesOverride }}
+    {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/.kratos"
+              service:
+                name: {{ $fullName }}-public
+                port:
+                  name: http
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: {{ include "galoyAuth.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end -}}
+    {{- end }}
+  tls:
+    {{- range .Values.ingress.hosts }}
+    - hosts:
+      - {{ . }}
+      secretName: {{ printf "%s-tls" . }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/stablesats/.helmignore
+++ b/charts/stablesats/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/stablesats/Chart.lock
+++ b/charts/stablesats/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.12.2
+digest: sha256:b990b435b2a739c542709db143d0f9d6fbc617ca15d17f39180b9bd5f97d49b9
+generated: "2022-08-06T21:10:55.408018+02:00"

--- a/charts/stablesats/Chart.yaml
+++ b/charts/stablesats/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+
+name: stablesats
+description: A Helm chart for Kubernetes
+
+type: application
+
+version: 0.1.0-dev
+
+appVersion: 0.1.3
+
+dependencies:
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.12.2

--- a/charts/stablesats/templates/_helpers.tpl
+++ b/charts/stablesats/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stablesats.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/stablesats/templates/stablesats-cm.yaml
+++ b/charts/stablesats/templates/stablesats-cm.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stablesats.fullname" . }}
+data:
+  stablesats.yml: |-
+    pubsub:
+{{- if .Values.stablesats.externalRedis }}
+{{- toYaml .Values.stablesats.externalRedis | nindent 6 }}
+{{- else }}
+      sentinel:
+        hosts:
+        - host: "{{ .Chart.Name }}-redis-node-0.{{ .Chart.Name }}-redis-headless"
+        - host: "{{ .Chart.Name }}-redis-node-1.{{ .Chart.Name }}-redis-headless"
+        - host: "{{ .Chart.Name }}-redis-node-2.{{ .Chart.Name }}-redis-headless"
+{{- end }}
+
+    price_server:
+      enabled: true
+      config:
+        listen_port: {{ .Values.stablesats.priceServer.port }}

--- a/charts/stablesats/templates/stablesats-deployment.yaml
+++ b/charts/stablesats/templates/stablesats-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "stablesats.fullname" . }}
+  labels:
+    app: {{ template "stablesats.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "stablesats.fullname" . }}
+      release: {{ .Release.Name }}
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: {{ template "stablesats.fullname" . }}
+        release: "{{ .Release.Name }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/stablesats-cm.yaml") . | sha256sum }}
+      {{- with .Values.stablesats.annotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.stablesats.image.repository }}@{{ .Values.stablesats.image.digest }}"
+        ports:
+        - containerPort: {{ .Values.stablesats.priceServer.port }}
+        args:
+        - stablesats
+        - run
+        volumeMounts:
+        - name: "config"
+          mountPath: "/stablesats.yml"
+          subPath: "stablesats.yml"
+        env:
+        - name: CRASH_REPORT_CONFIG
+          value: "true"
+        - name: STABLESATS_CONFIG
+          value: "/stablesats.yml"
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+            {{- if .Values.redis.auth.existingSecret }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+            {{- else }}
+              name: {{ template "stablesats.fullname" . }}-redis
+              key: "redis-password"
+
+            {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "stablesats.fullname" . }}

--- a/charts/stablesats/templates/stablesats-price-svc.yaml
+++ b/charts/stablesats/templates/stablesats-price-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "stablesats.fullname" . }}-price
+  labels:
+    app: {{ template "stablesats.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.stablesats.priceServer.port }}
+    targetPort: {{ .Values.stablesats.priceServer.port }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "stablesats.fullname" . }}

--- a/charts/stablesats/values.yaml
+++ b/charts/stablesats/values.yaml
@@ -1,0 +1,17 @@
+stablesats:
+  image:
+    repository: us.gcr.io/galoy-org/stablesats-rs
+    digest: "sha256:9ae3495f52c8c5b35d767ba11cf67a96b532f62b1119a134fe5bfbf9f7c2fadd"
+  priceServer:
+    port: 3325
+
+redis:
+  master:
+    persistence:
+      enabled: true
+  auth:
+    password: password
+  sentinel:
+    enabled: true
+  metrics:
+    enabled: true

--- a/dev/stablesats/main.tf
+++ b/dev/stablesats/main.tf
@@ -1,0 +1,41 @@
+variable "name_prefix" {
+  default = "galoy-dev"
+}
+
+locals {
+  stablesats_namespace     = "${var.name_prefix}-stablesats"
+}
+
+resource "kubernetes_namespace" "stablesats" {
+  metadata {
+    name = local.stablesats_namespace
+  }
+}
+
+resource "random_password" "redis" {
+  length  = 20
+  special = false
+}
+
+resource "kubernetes_secret" "redis_password" {
+  metadata {
+    name      = "stablesats-redis"
+    namespace = kubernetes_namespace.stablesats.metadata[0].name
+  }
+
+  data = {
+    "redis-password" : random_password.redis.result
+  }
+}
+
+resource "helm_release" "stablesats" {
+  name      = "stablesats"
+  chart     = "${path.module}/../../charts/stablesats"
+  namespace = kubernetes_namespace.stablesats.metadata[0].name
+
+  values = [
+    file("${path.module}/stablesats-values.yml")
+  ]
+
+  dependency_update = true
+}

--- a/dev/stablesats/out
+++ b/dev/stablesats/out
@@ -1,0 +1,1 @@
+password

--- a/dev/stablesats/stablesats-values.yml
+++ b/dev/stablesats/stablesats-values.yml
@@ -1,0 +1,4 @@
+redis:
+  auth:
+    existingSecret: "stablesats-redis"
+    existingSecretPasswordKey: "redis-password"


### PR DESCRIPTION
This is an initial version of the Stablesats chart.
It works locally (though hasn't been integrated into `dev/main.tf` to bring it up go to `dev/stablesats` and run `tf apply`) and I would like to start building the smoktest via iteration on concourse.