### PR TITLE
fix: redis auth

### DIFF
--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -150,8 +150,16 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if $.Values.redis.auth.existingSecret }}
+                  name: {{ $.Values.redis.auth.existingSecret }}
+                  {{- else }}
                   name: {{ $.Release.Name }}-redis
+                  {{- end }}
+                  {{- if $.Values.redis.auth.existingSecretPasswordKey }}
+                  key: {{ $.Values.redis.auth.existingSecretPasswordKey }}
+                  {{- else }}
                   key: "redis-password"
+                  {{- end }}
             - name: REDIS_0_DNS
               value: "galoy-redis-node-0.galoy-redis-headless"
             - name: REDIS_1_DNS


### PR DESCRIPTION
for migrating from the auto created redis secret to a pre-generated one
we must use a different name