### PR TITLE
ci: remove concurrency

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -1,5 +1,4 @@
 name: dev-smoketest
-concurrency: dev-smoketest
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Manually verified that removing concurrency actually sequentially adds jobs to self-hosted runner.