### PR TITLE
chore: specter update to v1.10.5

### DIFF
--- a/charts/specter/Chart.yaml
+++ b/charts/specter/Chart.yaml
@@ -16,8 +16,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1-dev
+version: 0.1.2-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.7.2
+appVersion: 1.10.5

--- a/charts/specter/values.yaml
+++ b/charts/specter/values.yaml
@@ -12,7 +12,7 @@ image:
   repository: lncm/specter-desktop
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.7.2"
+  tag: "v1.10.5"
 
 service:
   type: ClusterIP
@@ -33,7 +33,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: 
+podSecurityContext:
   fsGroup: 2000
 
 securityContext:


### PR DESCRIPTION
Updating to the latest version from https://hub.docker.com/r/lncm/specter-desktop/tags with a lot of bugfixes, features and no breaking changes: https://github.com/cryptoadvance/specter-desktop/releases/tag/v1.10.5

The old vesion is 9months old!