### PR TITLE
chore: update to loop v0.20.1

### DIFF
--- a/charts/lnd/charts/loop/Chart.yaml
+++ b/charts/lnd/charts/loop/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.11.1
+appVersion: 0.20.1

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command: ["/bin/sh","-c", "loopd --lnd.host={{ .Release.Name }}:10009 --network {{.Values.global.network}}"]
+          command: ["/bin/sh","-c", "loopd --experimental --lnd.host={{ .Release.Name }}:10009 --network {{.Values.global.network}}"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lnd/charts/loop/values.yaml
+++ b/charts/lnd/charts/loop/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: lightninglabs/loop
-  tag: v0.19.1-beta
+  tag: v0.20.1-beta
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
updating Loop to the latest in  https://hub.docker.com/r/lightninglabs/loop/tags

Does not make P2TR available yet as `loopd` needs to run with the `--experimental` flag 
(not present in the dockerfile), see:  https://github.com/lightninglabs/loop/releases/tag/v0.20.0-beta