### PR TITLE
feat: loopserver chart

### DIFF
--- a/charts/galoy/templates/cronjob.yaml
+++ b/charts/galoy/templates/cronjob.yaml
@@ -90,10 +90,20 @@ spec:
                 secretKeyRef:
                   name: lnd2-credentials
                   key: admin_macaroon_base64
+            - name: LND2_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND2_TLS
               valueFrom:
                 secretKeyRef:
                   name: lnd2-credentials
+                  key: tls_base64
+            - name: LND2_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
                   key: tls_base64
             - name: LND2_PUBKEY
               valueFrom:

--- a/charts/galoy/templates/cronjob.yaml
+++ b/charts/galoy/templates/cronjob.yaml
@@ -62,10 +62,20 @@ spec:
                 secretKeyRef:
                   name: lnd1-credentials
                   key: admin_macaroon_base64
+            - name: LND1_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND1_TLS
               valueFrom:
                 secretKeyRef:
                   name: lnd1-credentials
+                  key: tls_base64
+            - name: LND1_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
                   key: tls_base64
             - name: LND1_PUBKEY
               valueFrom:

--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -123,10 +123,20 @@ spec:
                 secretKeyRef:
                   name: lnd2-credentials
                   key: admin_macaroon_base64
+            - name: LND2_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND2_TLS
               valueFrom:
                 secretKeyRef:
                   name: lnd2-credentials
+                  key: tls_base64
+            - name: LND2_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
                   key: tls_base64
             - name: LND2_PUBKEY
               valueFrom:

--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -95,10 +95,20 @@ spec:
                 secretKeyRef:
                   name: lnd1-credentials
                   key: admin_macaroon_base64
+            - name: LND1_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: loop_macaroon_base64
             - name: LND1_TLS
               valueFrom:
                 secretKeyRef:
                   name: lnd1-credentials
+                  key: tls_base64
+            - name: LND1_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
                   key: tls_base64
             - name: LND1_PUBKEY
               valueFrom:

--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -18,6 +18,9 @@ dependencies:
   - name: loop
     version: x.x.x
     condition: loop.enabled
+  - name: loopserver
+    version: x.x.x
+    condition: loopserver.enabled
   - name: lndmon
     version: x.x.x
     condition: lndmon.enabled

--- a/charts/lnd/charts/loop/templates/export-secrets-configmap.yaml
+++ b/charts/lnd/charts/loop/templates/export-secrets-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-export-loop-secrets" (include "loop.fullname" .) }}
+  labels:
+    {{- include "loop.labels" . | nindent 4 }}
+data:
+  exportSecrets.sh: |
+    #!/bin/sh
+
+    export TLS=$(base64 /root/.loop/$NETWORK/tls.cert | tr -d '\n\r')
+    export MACAROON=$(base64 /root/.loop/$NETWORK/loop.macaroon | tr -d '\n\r')
+    mkdir macaroons
+    
+    cp /root/.loop/$NETWORK/*.macaroon macaroons
+    kubectl create secret generic {{ include "loop.fullname" . }}-credentials \
+    --from-literal=tls_base64=$TLS --from-file=/root/.loop/$NETWORK/tls.cert \
+    --from-literal=loop_macaroon_base64=$MACAROON --from-file=macaroons \
+    --dry-run=client -o yaml | kubectl apply -f -

--- a/charts/lnd/charts/loop/templates/role.yaml
+++ b/charts/lnd/charts/loop/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ include "loop.fullname" . }}
+  labels:
+    {{- include "loop.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "patch", "delete"]
+{{- end }}

--- a/charts/lnd/charts/loop/templates/rolebinding.yaml
+++ b/charts/lnd/charts/loop/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ include "loop.fullname" . }}
+  labels:
+    {{- include "loop.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "loop.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "loop.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/lnd/charts/loop/templates/serviceaccount.yaml
+++ b/charts/lnd/charts/loop/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "loop.serviceAccountName" . }}
+  labels:
+    {{- include "loop.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "loop.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -35,7 +36,20 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command: ["/bin/sh","-c", "loopd --lnd.host={{ .Release.Name }}:10009 --network {{.Values.global.network}}"]
+          args: 
+            - loopd
+            - --network={{.Values.global.network}}
+            {{- if eq .Values.global.network "regtest" }}
+            - --debuglevel=debug
+            - --server.host=lnd1-loopserver.galoy-dev-bitcoin.svc.cluster.local:11009
+            - --server.notls
+            {{- end }}
+            - --lnd.host={{ .Release.Name }}:10009
+            - --lnd.macaroonpath=/root/.lnd/data/chain/bitcoin/{{.Values.global.network}}/admin.macaroon
+            - --lnd.tlspath=/root/.lnd/tls.cert
+            - --tlsautorefresh
+            - --restlisten=0.0.0.0:8081
+            - --rpclisten=0.0.0.0:11010
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -69,6 +83,29 @@ spec:
               mountPath: "/root/.lnd/data/chain/bitcoin/{{.Values.global.network}}/"
             - name: loop-storage
               mountPath: /root/.loop
+        - name: export-secrets
+          image: "{{ .Values.sidecarImage.repository }}@{{ .Values.sidecarImage.digest }}"
+          command: ['/bin/sh']
+          args:
+          - '-c'
+          - |
+            loop -n $NETWORK terms
+            while [[ $? != 0 ]]; do sleep 1; loop -n $NETWORK terms; done
+            /home/alpine/exportSecrets.sh
+            trap "echo shutting down; exit 0" SIGKILL SIGTERM
+            while true; do sleep 1; done
+          env:
+          - name: NETWORK
+            valueFrom:
+              secretKeyRef:
+                name: network
+                key: network
+          volumeMounts:
+          - name: export-secrets
+            mountPath: /home/alpine/exportSecrets.sh
+            subPath: exportSecrets.sh
+          - name: loop-storage
+            mountPath: /root/.loop
       volumes:
       - name: lnd-tls
         secret:
@@ -79,6 +116,10 @@ spec:
       - name: lnd-macaroons
         secret:
           secretName: {{.Release.Name}}-credentials
+      - name: export-secrets
+        configMap:
+          name: {{ printf "%s-export-loop-secrets" (include "lnd.fullname" .) }}
+          defaultMode: 0777
       - name: loop-storage
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
           args: 
             - loopd
             - --network={{.Values.global.network}}
+            - --experimental
             {{- if eq .Values.global.network "regtest" }}
             - --debuglevel=debug
             - --server.host=lnd1-loopserver.galoy-dev-bitcoin.svc.cluster.local:11009

--- a/charts/lnd/charts/loop/values.yaml
+++ b/charts/lnd/charts/loop/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: lightninglabs/loop
-  tag: v0.19.1-beta
+  tag: v0.20.1-beta
   pullPolicy: IfNotPresent
 
 sidecarImage:

--- a/charts/lnd/charts/loopserver/.helmignore
+++ b/charts/lnd/charts/loopserver/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lnd/charts/loopserver/Chart.yaml
+++ b/charts/lnd/charts/loopserver/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lnd/charts/loopserver/Chart.yaml
+++ b/charts/lnd/charts/loopserver/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.11.1
+appVersion: v0.9.52

--- a/charts/lnd/charts/loopserver/Chart.yaml
+++ b/charts/lnd/charts/loopserver/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: loopserver
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.4
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: 0.11.1

--- a/charts/lnd/charts/loopserver/templates/_helpers.tpl
+++ b/charts/lnd/charts/loopserver/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "loop.name" -}}
+{{- define "loopserver.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "loop.fullname" -}}
+{{- define "loopserver.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "loop.chart" -}}
+{{- define "loopserver.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "loop.labels" -}}
-helm.sh/chart: {{ include "loop.chart" . }}
-{{ include "loop.selectorLabels" . }}
+{{- define "loopserver.labels" -}}
+helm.sh/chart: {{ include "loopserver.chart" . }}
+{{ include "loopserver.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,18 +45,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "loop.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "loop.name" . }}
+{{- define "loopserver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "loopserver.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "loop.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "loop.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/charts/lnd/charts/loopserver/templates/pvc.yml
+++ b/charts/lnd/charts/loopserver/templates/pvc.yml
@@ -1,0 +1,23 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "loopserver.fullname" $ }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "loopserver.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/lnd/charts/loopserver/templates/service.yaml
+++ b/charts/lnd/charts/loopserver/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loopserver.fullname" . }}
+  labels:
+    {{- include "loopserver.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      name: rpc
+  selector:
+    {{- include "loopserver.selectorLabels" . | nindent 4 }}

--- a/charts/lnd/charts/loopserver/templates/statefulset.yaml
+++ b/charts/lnd/charts/loopserver/templates/statefulset.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "loopserver.fullname" . }}
+  labels:
+    {{- include "loopserver.labels" . | nindent 4 }}
+    kube-monkey/identifier: {{ .Release.Name }}
+    {{- if .Values.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.labels "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  serviceName: {{ include "loopserver.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "loopserver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "loopserver.selectorLabels" . | nindent 8 }}
+        allow-to-lnd: "true"
+        kube-monkey/identifier: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args: 
+            - daemon
+            - --maxamt=5000000
+            - --lnd.host=lnd1.galoy-dev-bitcoin.svc.cluster.local:10009
+            - --lnd.macaroondir=/root/.lnd/data/chain/bitcoin/regtest
+            - --lnd.tlspath=/root/.lnd/tls.cert
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: rpc
+              containerPort: 11009
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: lnd-tls
+              mountPath: /root/.lnd/tls.cert
+              subPath: tls.cert
+            - name: lnd-macaroons
+              mountPath: "/root/.lnd/data/chain/bitcoin/regtest/"
+      volumes:
+      - name: lnd-tls
+        secret:
+          secretName: lnd1-credentials
+          items:
+          - key: tls.cert
+            path: "tls.cert"
+      - name: lnd-macaroons
+        secret:
+          secretName: lnd1-credentials
+      - name: loopserver-storage
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "loopserver.fullname" .) }}
+      {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lnd/charts/loopserver/templates/tests/test-connection.yaml
+++ b/charts/lnd/charts/loopserver/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "loopserver.fullname" . }}-test-connection"
+  labels:
+    {{- include "loopserver.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "loopserver.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/lnd/charts/loopserver/values.yaml
+++ b/charts/lnd/charts/loopserver/values.yaml
@@ -3,13 +3,9 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: lightninglabs/loop
-  tag: v0.19.1-beta
+  repository: lightninglabs/loopserver
+  tag: v0.9.52-beta
   pullPolicy: IfNotPresent
-
-sidecarImage:
-  repository: ntheile/lnd-sidecar
-  digest: "sha256:fde4b3a7506f19d0792b958c45bfca60449f1e220dd24731ab1e75577c7eb211"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -30,7 +26,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8081
+  port: 11009
 
 resources:
   limits:

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -96,6 +96,8 @@ lndGeneralConfig:
 bitcoindRpcPassSecretName: bitcoind-rpcpassword
 loop:
   enabled: true
+loopserver:
+  enabled: false
 lndmon:
   enabled: true
 rbac:

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -173,6 +173,22 @@ resource "kubernetes_secret" "lnd2_credentials" {
   data = data.kubernetes_secret.lnd2_credentials.data
 }
 
+data "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd2-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd2-loop-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd2_loop_credentials.data
+}
+
 data "kubernetes_secret" "lnd1_credentials" {
   metadata {
     name      = "lnd1-credentials"

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -189,6 +189,22 @@ resource "kubernetes_secret" "lnd1_credentials" {
   data = data.kubernetes_secret.lnd1_credentials.data
 }
 
+data "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd1_loop_credentials.data
+}
+
 resource "kubernetes_namespace" "testflight" {
   metadata {
     name = local.testflight_namespace

--- a/ci/testflight/rtl/main.tf
+++ b/ci/testflight/rtl/main.tf
@@ -30,6 +30,22 @@ resource "kubernetes_secret" "lnd1_credentials" {
   data = data.kubernetes_secret.lnd1_credentials.data
 }
 
+data "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd-loop-credentials"
+    namespace = "galoy-staging-bitcoin"
+  }
+}
+
+resource "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd1_loop_credentials.data
+}
+
 resource "kubernetes_secret" "smoketest" {
   metadata {
     name      = local.testflight_namespace

--- a/dev/bitcoin/lnd-values.yml
+++ b/dev/bitcoin/lnd-values.yml
@@ -21,4 +21,6 @@ configmap:
   - tlsextradomain=lnd1.galoy-dev-bitcoin.svc.cluster.local
 
 loop:
-  enabled: false
+  enabled: true
+loopserver:
+  enabled: true

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -169,6 +169,22 @@ resource "kubernetes_secret" "lnd2_credentials" {
   data = data.kubernetes_secret.lnd2_credentials.data
 }
 
+data "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd2-loop-credentials"
+    namespace = kubernetes_namespace.galoy.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd2_loop_credentials.data
+}
+
 data "kubernetes_secret" "lnd1_credentials" {
   metadata {
     name      = "lnd1-credentials"

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -185,6 +185,22 @@ resource "kubernetes_secret" "lnd1_credentials" {
   data = data.kubernetes_secret.lnd1_credentials.data
 }
 
+data "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = kubernetes_namespace.galoy.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd1_loop_credentials.data
+}
+
 resource "helm_release" "galoy" {
   name      = "galoy"
   chart     = "${path.module}/../../charts/galoy"

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,8 +1,10 @@
 FROM lightninglabs/lnd:v0.15.0-beta as lnd
+FROM lightninglabs/loop:v0.19.1-beta as loop
 
 FROM alpine/k8s:1.21.5
 
 COPY --from=lnd /bin/lncli /bin/lncli
+COPY --from=loop /bin/loop /bin/loop
 
 RUN apk --update add expect curl jq
 

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,5 +1,5 @@
 FROM lightninglabs/lnd:v0.15.0-beta as lnd
-FROM lightninglabs/loop:v0.19.1-beta as loop
+FROM lightninglabs/loop:v0.20.1-beta as loop
 
 FROM alpine/k8s:1.21.5
 


### PR DESCRIPTION
This PR adds a new chart called loopserver to be used in dev charts (regtest) and smoketest environments. It also copies the loop macaroon to kubernetes secrets to be consumed by the galoy main backend and cron servers. 