### PR TITLE
fix: helm context for bitcoind prometheus port

### DIFF
--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
         prometheus.io/path: /metrics
-        prometheus.io/port: {{ .Values.service.ports.metrics | quote }}
+        prometheus.io/port: {{ $.Values.service.ports.metrics | quote }}
         prometheus.io/scrape: "true"
     {{- end }}
       labels:


### PR DESCRIPTION
Just a small error I've noticed. The context is wrong thus helm would fail when supplying this with a values file.