### PR TITLE
feat: add loop env vars to galoy deployment

### DIFF
--- a/charts/galoy/templates/cronjob.yaml
+++ b/charts/galoy/templates/cronjob.yaml
@@ -72,6 +72,16 @@ spec:
                 secretKeyRef:
                   name: lnd1-pubkey
                   key: pubkey
+            - name: LND1_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: loop_macaroon_base64
+            - name: LND1_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: tls_base64
 
             - name: LND2_DNS
               value: {{ $.Values.lnd2.dns }}
@@ -90,6 +100,16 @@ spec:
                 secretKeyRef:
                   name: lnd2-pubkey
                   key: pubkey
+            - name: LND2_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: loop_macaroon_base64
+            - name: LND2_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: tls_base64
             - name: BITCOINDADDR
               value: {{ $.Values.bitcoind.address }}
             - name: BITCOINDRPCPASS

--- a/charts/galoy/templates/deployment.yaml
+++ b/charts/galoy/templates/deployment.yaml
@@ -105,6 +105,16 @@ spec:
                 secretKeyRef:
                   name: lnd1-pubkey
                   key: pubkey
+            - name: LND1_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: loop_macaroon_base64
+            - name: LND1_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd1-loop-credentials
+                  key: tls_base64
 
             - name: LND2_DNS
               value: {{ $.Values.lnd2.dns }}
@@ -123,6 +133,16 @@ spec:
                 secretKeyRef:
                   name: lnd2-pubkey
                   key: pubkey
+            - name: LND2_LOOP_MACAROON
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: loop_macaroon_base64
+            - name: LND2_LOOP_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: lnd2-loop-credentials
+                  key: tls_base64
 
             - name: BITCOINDADDR
               value: {{ $.Values.bitcoind.address }}

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -189,6 +189,38 @@ resource "kubernetes_secret" "lnd1_credentials" {
   data = data.kubernetes_secret.lnd1_credentials.data
 }
 
+data "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd1_loop_credentials" {
+  metadata {
+    name      = "lnd1-loop-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd1_loop_credentials.data
+}
+
+data "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd2-loop-credentials"
+    namespace = local.bitcoin_namespace
+  }
+}
+
+resource "kubernetes_secret" "lnd2_loop_credentials" {
+  metadata {
+    name      = "lnd2-loop-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = data.kubernetes_secret.lnd2_loop_credentials.data
+}
+
 resource "kubernetes_namespace" "testflight" {
   metadata {
     name = local.testflight_namespace
@@ -250,8 +282,10 @@ resource "helm_release" "galoy" {
   depends_on = [
     kubernetes_secret.bitcoinrpc_password,
     kubernetes_secret.lnd1_credentials,
+    kubernetes_secret.lnd1_loop_credentials,
     kubernetes_secret.lnd1_pubkey,
     kubernetes_secret.lnd2_credentials,
+    kubernetes_secret.lnd2_loop_credentials,
     kubernetes_secret.lnd2_pubkey,
     kubernetes_secret.price_history_postgres_creds
   ]

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -230,8 +230,10 @@ resource "helm_release" "galoy" {
   depends_on = [
     kubernetes_secret.bitcoinrpc_password,
     kubernetes_secret.lnd1_credentials,
+    kubernetes_secret.lnd1_loop_credentials,
     kubernetes_secret.lnd1_pubkey,
     kubernetes_secret.lnd2_credentials,
+    kubernetes_secret.lnd2_loop_credentials,
     kubernetes_secret.lnd2_pubkey,
     kubernetes_secret.price_history_postgres_creds
   ]


### PR DESCRIPTION
Test that the env var exists `LND1_LOOP_MACAROON` in the main galoy api

```
APPNAME=api; \
POD=$(k get pod -A -l app=$APPNAME -o jsonpath="{.items[0].metadata.name}"); \
NS=$(k get pod -A -l app=$APPNAME -o jsonpath="{.items[0].metadata.namespace}"); \
k -n $NS describe pod $POD | grep LND1_LOOP_MACAROON;
```

Result should be
```
LND1_LOOP_MACAROON:       <set to the key 'loop_macaroon_base64' in secret 'lnd1-loop-credentials'>  Optional: false
```