### PR TITLE
chore: update bitcoind to v23

### DIFF
--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: lncm/bitcoind
   pullPolicy: IfNotPresent
-  tag: v22.0
+  tag: v23.0
 
 extraInitContainers: []
 sidecarContainers: []


### PR DESCRIPTION
associated PR on galoy: https://github.com/GaloyMoney/galoy/pull/1631