### PR TITLE
Lndmon update to support Taproot addresses

### DIFF
--- a/charts/lnd/charts/lndmon/Chart.yaml
+++ b/charts/lnd/charts/lndmon/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: 0.2.1

--- a/charts/lnd/charts/lndmon/templates/deployment.yaml
+++ b/charts/lnd/charts/lndmon/templates/deployment.yaml
@@ -46,14 +46,14 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: /metrics
               port: http
             timeoutSeconds: 30
             periodSeconds: 30
             failureThreshold: 6
           readinessProbe:
             httpGet:
-              path: /health
+              path: /metrics
               port: http
             timeoutSeconds: 30
             periodSeconds: 30

--- a/charts/lnd/charts/lndmon/templates/deployment.yaml
+++ b/charts/lnd/charts/lndmon/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command: ["/bin/sh", "-c", "lndmon --lnd.host={{.Release.Name}}:10009 --lnd.network {{.Values.global.network}} --prometheus.listenaddr=0.0.0.0:9092 --health.active"]
+          command: ["/bin/sh", "-c", "lndmon --lnd.host={{.Release.Name}}:10009 --lnd.network {{.Values.global.network}} --prometheus.listenaddr=0.0.0.0:9092"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/lnd/charts/lndmon/values.yaml
+++ b/charts/lnd/charts/lndmon/values.yaml
@@ -5,10 +5,10 @@
 replicaCount: 1
 
 image:
-  repository: radarion/lndmon
+  repository: lightninglabs/lndmon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.2.0
+  tag: v0.2.1
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Fixing the errors:
```
Lndmon exiting with error: WalletCollector ListUnspent failed with: invalid utxo address type 4
```
by updating the 2 years old lndmon version (no P2TR support) to the latest https://hub.docker.com/layers/lightninglabs/lndmon/v0.2.1/images/sha256-131497041d6bbf1b164062162c31068dd0dbf8f4bbb065bb44fcadecc5ef52e0?context=explore

Tested the new version locally with taproot addresses on regtest by running:
```
kubectl -n galoy-dev-bitcoin exec bitcoind-0 -- bitcoin-cli createwallet default
kubectl -n galoy-dev-bitcoin exec bitcoind-0 -- bitcoin-cli generatetoaddress 1 $(kubectl -n  galoy-dev-bitcoin exec -it lnd1-0 -c lnd -- lncli -n regtest newaddress p2tr | jq -r .address)
kubectl -n galoy-dev-bitcoin exec bitcoind-0 -- bitcoin-cli -generate 106
```

The `/health` endpoint is not present any more so needed to remove the flag.
Was giving:
```
k -n galoy-dev-bitcoin  logs $(kubectl get pods -A | grep lndmon | awk '{print $2}') -f
unknown flag `health.active'
```

The differences in lndmon options are:
```
k -n galoy-dev-bitcoin exec -it $(kubectl get pods -A | grep lndmon | awk '{print $2}')  -- lndmon --help
```
New:
```
Usage:
  lndmon [OPTIONS]

Application Options:
      --primarynode=                                 Public key of the primary node in a primary-gateway setup
      --disablegraph                                 Do not collect graph metrics

prometheus:
      --prometheus.listenaddr=                       the interface we should listen on for prometheus (default: localhost:9092)
      --prometheus.logdir=                           Directory to log output (default: /root/.lndmon/logs)
      --prometheus.maxlogfiles=                      Maximum log files to keep (0 for no rotation) (default: 3)
      --prometheus.maxlogfilesize=                   Maximum log file size in MB (default: 10)

lnd:
      --lnd.host=                                    lnd instance rpc address (default: localhost:10009)
      --lnd.network=[regtest|testnet|mainnet|simnet] network to run on (default: mainnet)
      --lnd.macaroondir=                             Path to lnd macaroons (default: /root/.lnd)
      --lnd.macaroonname=                            The name of our macaroon in macaroon dir to use. (default: readonly.macaroon)
      --lnd.tlspath=                                 Path to lnd tls certificate

Help Options:
  -h, --help                                         Show this help message
```
vs the old:
```
lndmon [OPTIONS]

Application Options:
      --primarynode=                                 Public key of the primary node in a primary-gateway setup

prometheus:
      --prometheus.listenaddr=                       the interface we should listen on for prometheus (default: localhost:9092)
      --prometheus.logdir=                           Directory to log output (default: /root/.lndmon/logs)
      --prometheus.maxlogfiles=                      Maximum log files to keep (0 for no rotation) (default: 3)
      --prometheus.maxlogfilesize=                   Maximum log file size in MB (default: 10)

lnd:
      --lnd.host=                                    lnd instance rpc address (default: localhost:10009)
      --lnd.network=[regtest|testnet|mainnet|simnet] network to run on (default: mainnet)
      --lnd.macaroondir=                             Path to lnd macaroons (default: /root/.lnd)
      --lnd.macaroonname=                            The name of our macaroon in macaroon dir to use. (default: readonly.macaroon)
      --lnd.tlspath=                                 Path to lnd tls certificate

health:
      --health.active                                If the health check should be active or not
      --health.path=                                 path to listen for healtcheck requests (default: /health)

Help Options:
  -h, --help 
  ```