### PR TITLE
fix: add '-f' option to curl requests

### DIFF
--- a/ci/tasks/admin-panel-smoketest.sh
+++ b/ci/tasks/admin-panel-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "admin_panel_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl admin panel"
-  curl --location ${host}:${port}
+  curl --location -f ${host}:${port}
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/dealer-smoketest.sh
+++ b/ci/tasks/dealer-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "dealer_port"`
 set +e
 for i in {1..30}; do
   echo "Attempt ${i} to curl dealer's /metrics endpoint"
-  curl --location ${host}:${port}/metrics
+  curl --location -f ${host}:${port}/metrics
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 5
 done

--- a/ci/tasks/galoy-auth-smoketest.sh
+++ b/ci/tasks/galoy-auth-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "galoy_auth_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl galoy-auth"
-  curl --location ${host}:${port}
+  curl --location -f ${host}:${port}
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/galoy-pay-smoketest.sh
+++ b/ci/tasks/galoy-pay-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "galoy_pay_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl galoy pay"
-  curl --location ${host}:${port}
+  curl --location -f ${host}:${port}
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/specter-smoketest.sh
+++ b/ci/tasks/specter-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "specter_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl specter"
-  curl ${host}:${port} | grep direct # Check if we are being redirected
+  curl -f ${host}:${port} | grep direct # Check if we are being redirected
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/web-wallet-smoketest.sh
+++ b/ci/tasks/web-wallet-smoketest.sh
@@ -13,7 +13,7 @@ for i in {1..15}; do
   echo "Attempt ${i} to curl web wallet"
   curl --location ${host}:${port}
   status=$?
-  curl --location ${web_wallet_mobile_host}:${port}
+  curl --location -f ${web_wallet_mobile_host}:${port}
   if [[ $status == 0 ]] && [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done


### PR DESCRIPTION
## What this PR does?
- add `-f` option to curl requests to address non-zero exit code of non-200 and non-201 requests.