### PR TITLE
chore: smoketests should fail when response is non 200

### DIFF
--- a/ci/tasks/lnd-smoketest.sh
+++ b/ci/tasks/lnd-smoketest.sh
@@ -10,7 +10,7 @@ lnd_host=`setting "lnd_p2p_endpoint"`
 set +e
 for i in {1..60}; do
   echo "Attempt ${i} to curl lndmon"
-  curl ${lndmon_host}:9092/metrics
+  curl -f ${lndmon_host}:9092/metrics
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/rtl-smoketest.sh
+++ b/ci/tasks/rtl-smoketest.sh
@@ -10,7 +10,7 @@ port=`setting "rtl_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl rtl"
-  curl ${host}:${port}
+  curl -f ${host}:${port}
   if [[ $? == 0 ]]; then success="true"; break; fi;
   sleep 1
 done

--- a/ci/tasks/web-wallet-smoketest.sh
+++ b/ci/tasks/web-wallet-smoketest.sh
@@ -11,7 +11,7 @@ port=`setting "web_wallet_port"`
 set +e
 for i in {1..15}; do
   echo "Attempt ${i} to curl web wallet"
-  curl --location ${host}:${port}
+  curl --location -f ${host}:${port}
   status=$?
   curl --location -f ${web_wallet_mobile_host}:${port}
   if [[ $status == 0 ]] && [[ $? == 0 ]]; then success="true"; break; fi;


### PR DESCRIPTION
Originally raised this on the wrong repo here https://github.com/GaloyMoney/galoy-deployments/pull/2181.  Some of the changes don't seem to have been synced by vendir 

The following file is out of sync (curl command is different)
modules/services/auth/vendor/galoy-auth/ci/tasks/galoy-auth-smoketest.sh

The following file has not been deleted but isn't present in charts
modules/services/client-addons/vendor/guatt-web-wallet/ci/tasks/guatt-web-wallet-smoketest.sh
