### PR TITLE
fix: lnd chart.lock didn't contain loopserver

### DIFF
--- a/charts/lnd/Chart.lock
+++ b/charts/lnd/Chart.lock
@@ -5,11 +5,14 @@ dependencies:
 - name: loop
   repository: ""
   version: x.x.x
+- name: loopserver
+  repository: ""
+  version: x.x.x
 - name: lndmon
   repository: ""
   version: x.x.x
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.19
-digest: sha256:6a4a8473f85ff149591396c0e2ebe47339855f1846f5fb7f6dc196e660aba1e6
-generated: "2022-08-15T21:08:35.497533254Z"
+digest: sha256:151207bcc22a10768852766591640be595487b104c1cf3f3da3c6f1a5f3303ce
+generated: "2022-09-23T11:58:16.08648+05:30"


### PR DESCRIPTION
Fixes https://github.com/GaloyMoney/charts/issues/1667
Rollout should be LND no-op.