### PR TITLE
fix: remove postgresql from dealer chart.lock

### DIFF
--- a/charts/dealer/Chart.lock
+++ b/charts/dealer/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.7.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.13.0
-digest: sha256:42cb0e05843fcc496b00575fee1c0f1ed704ab773d1a7c9a40589096661b9917
-generated: "2022-08-16T21:37:24.612219801Z"
+digest: sha256:ab00a89396dca4c96bf4b12e81a8b019aca6aafacbf11cd05961ba843c2093f8
+generated: "2022-09-23T12:20:43.22075+05:30"


### PR DESCRIPTION
Syncs Chart.lock with Chart.yaml, must be a No OP rollout.
Similar to https://github.com/GaloyMoney/charts/pull/1668