### PR TITLE
fix: add galoy api ingress and use https test in dev

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -21,11 +21,11 @@ make deploy
 
 Test if its working:
 ```
-kubectl -n galoy-dev-ingress port-forward svc/ingress-nginx-controller 8080:80
+kubectl -n galoy-dev-ingress port-forward svc/ingress-nginx-controller 8080:443
 ```
 In other terminal:
 ```
-$ curl 'localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+59981730222","code":"111111"}}}'
+$ curl -k 'https://localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+59981730222","code":"111111"}}}'
 {"data":{"userLogin":{"authToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiI2MTc2YmQ2NmQ0MmFkYWIzNjM2MmEyY2QiLCJuZXR3b3JrIjoibWFpbm5ldCIsImlhdCI6MTYzNTE3MTY4Nn0.n-p5sA9meAmZrVOdngYr216jG3LKOFsFdJmVw6XND3A"}}}
 ```
 

--- a/dev/galoy/galoy-values.yml
+++ b/dev/galoy/galoy-values.yml
@@ -25,6 +25,11 @@ galoy:
   dealer:
     host: dealer-price.galoy-dev-addons.svc.cluster.local
 
+  api:
+    ingress:
+      enabled: true
+      host: localhost
+
 mongodb:
   architecture: standalone
   volumePermissions:


### PR DESCRIPTION
related to  the changes in #1389

fixes #1683  

The test output is now:
```
$ curl -k 'https://localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+59981730222","code":"111111"}}}'

{"errors":[{"message":"missing key for twilio","locations":[{"line":1,"column":43}],"path":["userLogin"],"code":"INTERNAL_SERVER_ERROR"}],"data":null}
```

Ingress works and will deal with Twilio in a later change.