### PR TITLE
fix: nginx websocket connections

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -17,6 +17,7 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"
     nginx.ingress.kubernetes.io/limit-connections: "40"
+    nginx.org/websocket-services: {{ template "galoy.api.fullname" . }}
 
 spec:
   tls:


### PR DESCRIPTION
@daviroo 

I tested in my local charts dev environment and it appears to have deployed nginx successfully. I also tested a simple subscription graphql query in the playground and it all worked. I am not quite sure how to check the nginx logs to see if the errors are gone.

```
nick@nuc:~/code/charts/dev$ kubectl -n galoy-dev-galoy describe ingress
Name:             api
Labels:           app=api
                  app.kubernetes.io/managed-by=Helm
                  chart=galoy-0.5.15-dev
                  release=galoy
Namespace:        galoy-dev-galoy
Address:          10.43.31.17
Ingress Class:    <none>
Default backend:  <default>
TLS:
  api-ingress-tls terminates localhost
Rules:
  Host        Path  Backends
  ----        ----  --------
  localhost   
              /   api:4002 (10.42.0.31:4002,10.42.0.36:4002)
Annotations:  cert-manager.io/cluster-issuer: letsencrypt-issuer
              kubernetes.io/ingress.class: nginx
              meta.helm.sh/release-name: galoy
              meta.helm.sh/release-namespace: galoy-dev-galoy
              nginx.ingress.kubernetes.io/limit-burst-multiplier: 40
              nginx.ingress.kubernetes.io/limit-connections: 40
              nginx.ingress.kubernetes.io/limit-rpm: 60
              nginx.org/websocket-services: api
Events:
  Type    Reason             Age                    From                      Message
  ----    ------             ----                   ----                      -------
  Normal  CreateCertificate  6m29s                  cert-manager              Successfully created Certificate "api-ingress-tls"
  Normal  Sync               6m14s (x2 over 6m29s)  nginx-ingress-controller  Scheduled for sync
```