### PR TITLE
feat: add RTL to the dev setup

### DIFF
--- a/dev/bitcoin/main.tf
+++ b/dev/bitcoin/main.tf
@@ -48,3 +48,14 @@ resource "kubernetes_secret" "lnd_smoketest" {
     lnd_p2p_endpoint = "lnd1-p2p.${local.bitcoin_namespace}.svc.cluster.local"
   }
 }
+
+resource "kubernetes_secret" "rtl_smoketest" {
+  metadata {
+    name      = "rtl-smoketest"
+    namespace = local.smoketest_namespace
+  }
+  data = {
+    rtl_endpoint = "rtl.${local.bitcoin_namespace}.svc.cluster.local"
+    rtl_port     = 3000
+  }
+}

--- a/dev/bitcoin/rtl.tf
+++ b/dev/bitcoin/rtl.tf
@@ -1,12 +1,9 @@
 resource "helm_release" "rtl" {
-  name       = "rtl"
-  chart      = "${path.module}/../../charts/rtl"
-  namespace  = kubernetes_namespace.bitcoin.metadata[0].name
+  name      = "rtl"
+  chart     = "${path.module}/../../charts/rtl"
+  namespace = kubernetes_namespace.bitcoin.metadata[0].name
 
   dependency_update = true
-  values = [
-    file("${path.module}/rtl-values.yml")
-  ]
 
   depends_on = [
     helm_release.lnd

--- a/dev/bitcoin/rtl.tf
+++ b/dev/bitcoin/rtl.tf
@@ -1,0 +1,14 @@
+resource "helm_release" "rtl" {
+  name       = "rtl"
+  chart      = "${path.module}/../../charts/rtl"
+  namespace  = kubernetes_namespace.bitcoin.metadata[0].name
+
+  dependency_update = true
+  values = [
+    file("${path.module}/rtl-values.yml")
+  ]
+
+  depends_on = [
+    helm_release.lnd
+  ]
+}


### PR DESCRIPTION
Adding RTL to the local dev deployment.

To access RTL on the local regtest:
```
env=galoy-dev

# get the password
k -n ${env}-bitcoin get secrets rtl-pass -o jsonpath='{.data.password}' | base64 -d

# forward the port from the pod
k -n ${env}-bitcoin port-forward  $(kubectl get pods -A | grep rtl | awk '{print $2}')  3000:3000

# access RTL on your http://localhost:3000
```

Next step is to update update to the [latest version](https://hub.docker.com/layers/shahanafarooqui/rtl/0.13.1/images/sha256-1d2892e29b5ccc4e9768ce0e7764bc9a1fd46c82d02131204f22a6aa239e106b?context=explore),but it doesn't work yet out of the box due to configuration changes.