### PR TITLE
chore: use ingressClassName instead of annotation to specify ingress

### DIFF
--- a/charts/admin-panel/templates/ingress.yaml
+++ b/charts/admin-panel/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-issuer
 spec:
+  ingressClassName: nginx
   rules:
     {{- if .Values.ingress.rulesOverride }}
     {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}

--- a/charts/bitcoind/templates/ingress.yaml
+++ b/charts/bitcoind/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/galoy-auth/templates/ingress.yaml
+++ b/charts/galoy-auth/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-issuer
 spec:
+  ingressClassName: nginx
   rules:
     {{- if .Values.ingress.rulesOverride }}
     {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}

--- a/charts/galoy-pay/templates/ingress.yaml
+++ b/charts/galoy-pay/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-issuer
 spec:
+  ingressClassName: nginx
   rules:
     {{- if .Values.ingress.rulesOverride }}
     {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}

--- a/charts/galoy/charts/price/templates/ingress.yaml
+++ b/charts/galoy/charts/price/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/galoy/templates/admin-ingress.yaml
+++ b/charts/galoy/templates/admin-ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ .Values.galoy.admin.ingress.clusterIssuer }}
 
     nginx.ingress.kubernetes.io/limit-rpm: "10"
@@ -29,6 +28,7 @@ metadata:
       proxy_set_header X-Forwarded-Uri $request_uri;
 
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - {{ .Values.galoy.admin.ingress.host }}

--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
 
     nginx.ingress.kubernetes.io/limit-rpm: "60"
@@ -29,6 +28,7 @@ metadata:
       proxy_set_header X-Forwarded-Uri $request_uri;
 
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - {{ .Values.galoy.api.ingress.host }}

--- a/charts/lnd/charts/lndmon/templates/ingress.yaml
+++ b/charts/lnd/charts/lndmon/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/specter/templates/ingress.yaml
+++ b/charts/specter/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/web-wallet/templates/ingress.yaml
+++ b/charts/web-wallet/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-issuer
 spec:
+  ingressClassName: nginx
   rules:
     {{- if .Values.ingress.rulesOverride }}
     {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}


### PR DESCRIPTION
`kubernetes.io/ingress.class` is now a deprecated annotation: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

NGINX Ingress Controller already works with this newer spec, hence updating all our Ingresses.