### PR TITLE
fix: swap tls extra domain

### DIFF
--- a/charts/lnd/charts/loop/templates/statefulset.yaml
+++ b/charts/lnd/charts/loop/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          args: 
+          args:
             - loopd
             - --network={{.Values.global.network}}
             - --experimental
@@ -49,6 +49,7 @@ spec:
             - --lnd.macaroonpath=/root/.lnd/data/chain/bitcoin/{{.Values.global.network}}/admin.macaroon
             - --lnd.tlspath=/root/.lnd/tls.cert
             - --tlsautorefresh
+            - --tlsextradomain={{ include "loop.fullname" . }}
             - --restlisten=0.0.0.0:8081
             - --rpclisten=0.0.0.0:11010
           securityContext:

--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -12,7 +12,17 @@ galoy:
         needUsdWallet: true
     apollo:
       playground: true
-  
+    swap:
+      loopOutWhenHotWalletLessThan: 500000
+      swapOutAmount:  250000
+      swapProviders: ["Loop"]
+      lnd1loopRestEndpoint: https://lnd1-loop.galoy-dev-bitcoin.svc.cluster.local:8081
+      lnd1loopRpcEndpoint: lnd1-loop.galoy-dev-bitcoin.svc.cluster.local:11010
+      lnd2loopRestEndpoint: https://lnd1-loop.galoy-dev-bitcoin.svc.cluster.local:8081
+      lnd2loopRpcEndpoint: lnd1-loop.galoy-dev-bitcoin.svc.cluster.local:11010
+    cronConfig:
+      swapEnabled: true
+
   bitcoind:
     dns: bitcoind.galoy-dev-bitcoin.svc.cluster.local
     port: 18332
@@ -22,7 +32,7 @@ galoy:
 
   lnd2:
     dns: lnd1.galoy-dev-bitcoin.svc.cluster.local
-  
+
   dealer:
     host: dealer-price.galoy-dev-addons.svc.cluster.local
 

--- a/dev/galoy/galoy-signet-values.yml
+++ b/dev/galoy/galoy-signet-values.yml
@@ -12,7 +12,17 @@ galoy:
         needUsdWallet: true
     apollo:
       playground: true
-  
+    swap:
+      loopOutWhenHotWalletLessThan: 500000
+      swapOutAmount:  250000
+      swapProviders: ["Loop"]
+      lnd1loopRestEndpoint: https://lnd1-loop.galoy-sig-bitcoin.svc.cluster.local:8081
+      lnd1loopRpcEndpoint: lnd1-loop.galoy-sig-bitcoin.svc.cluster.local:11010
+      lnd2loopRestEndpoint: https://lnd1-loop.galoy-sig-bitcoin.svc.cluster.local:8081
+      lnd2loopRpcEndpoint: lnd1-loop.galoy-sig-bitcoin.svc.cluster.local:11010
+    cronConfig:
+      swapEnabled: false
+
   bitcoind:
     dns: bitcoind.galoy-sig-bitcoin.svc.cluster.local
     port: 38332


### PR DESCRIPTION
This PR adds a flag for `--tlsextradomain` to the loop chart that points to loops kubernetes dns