### PR TITLE
chore: add galoy-deps testflight

### DIFF
--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -221,7 +221,7 @@ params:
 name: #@ deployment + "-slack"
 type: slack-notification
 source:
-  url: #@ getattr(data.values, deployment + "_slack_webhook_url")
+  url: #@ getattr(data.values, deployment.replace("-", "_") + "_slack_webhook_url")
 #@ end
 
 #@ def repo_out_resource(repo_name):

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -71,6 +71,9 @@ groups:
   jobs:
   - stablesats-testflight
   - bump-stablesats-in-deployments
+- name: galoy-deps
+  jobs:
+  - galoy-deps-testflight
 - name: images
   jobs:
   - build-chain-dl-image
@@ -96,6 +99,7 @@ jobs:
 - #@ bump_in_deployments_job("galoy-auth")
 - #@ testflight_job("stablesats", "stablesats", stablesats_chart_vars())
 - #@ bump_in_deployments_job("stablesats")
+- #@ testflight_job("galoy-deps", "galoy-deps")
 
 - name: build-chain-dl-image
   serial: true
@@ -311,6 +315,10 @@ resources:
 - #@ chart_repo_resource("galoy-auth")
 - #@ testflight_tf_resource("galoy-auth")
 - #@ slack_resource("auth")
+
+- #@ chart_repo_resource("galoy-deps")
+- #@ testflight_tf_resource("galoy-deps")
+- #@ slack_resource("galoy-deps")
 
 - name: charts-repo
   type: git

--- a/ci/testflight/galoy-deps/main.tf
+++ b/ci/testflight/galoy-deps/main.tf
@@ -1,0 +1,7 @@
+resource "helm_release" "galoy_deps" {
+  name      = "galoy-deps"
+  chart     = "${path.module}/chart"
+  namespace = kubernetes_namespace.testflight.metadata[0].name
+
+  dependency_update = true
+}

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -28,4 +28,5 @@ bitcoin_slack_webhook_url: ((bitcoin-slack.api_url))
 addons_slack_webhook_url: ((addons-slack.api_url))
 auth_slack_webhook_url: ((auth-slack.api_url))
 stablesats_slack_webhook_url: ((addons-slack.api_url))
+galoy_deps_slack_webhook_url: ((addons-slack.api_url))
 slack_username: concourse


### PR DESCRIPTION
Using the addons slack for galoy-deps pipeline notifications for now until credential provisioning is blocked. Will replace it in a subsequent PR.