### PR TITLE
chore: update lnd docker images to v0.15.3-beta

### DIFF
--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lnd
 version: 0.3.5-dev
-appVersion: 0.15.2
+appVersion: 0.15.3
 description: LND helm chart
 keywords:
   - lnd

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -2,7 +2,7 @@ global:
   network: mainnet
 image:
   repository: lightninglabs/lnd
-  tag: v0.15.2-beta
+  tag: v0.15.3-beta
   pullPolicy: IfNotPresent
 sidecarImage:
   repository: us.gcr.io/galoy-org/lnd-sidecar

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM lightninglabs/lnd:v0.15.2-beta as lnd
+FROM lightninglabs/lnd:v0.15.3-beta as lnd
 FROM lightninglabs/loop:v0.20.1-beta as loop
 
 FROM alpine/k8s:1.21.5


### PR DESCRIPTION
There are no breaking changes, but a few Taproot related bugs are fixed: https://github.com/lightningnetwork/lnd/blob/v0-15-3-branch/docs/release-notes/release-notes-0.15.3.md