### PR TITLE
chore: Increased proxy timeouts for websockets

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -13,6 +13,9 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
 
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "21600" # 6 hours
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "21600" # 6 hours
+
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"
     nginx.ingress.kubernetes.io/limit-connections: "40"

--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -13,8 +13,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
 
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "21600" # 6 hours
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "21600" # 6 hours
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
 
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"


### PR DESCRIPTION
I found some docs on websockets config for kubernetes nginx - it says we should have a higher value for some configs for proxy for websockets.

https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets