### PR TITLE
chore: Increased connections limit for api ingress

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -18,7 +18,7 @@ metadata:
 
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"
-    nginx.ingress.kubernetes.io/limit-connections: "40"
+    nginx.ingress.kubernetes.io/limit-connections: "80"
 
     nginx.ingress.kubernetes.io/auth-url: "http://galoy-oathkeeper-api.{{ .Release.Namespace }}.svc.cluster.local:4456/decisions"
     nginx.ingress.kubernetes.io/auth-method: GET


### PR DESCRIPTION
I can see in the logs that we are actually rate limiting based on number of connections coming from an IP.  I've doubled it for now to see what effect it will have (previously 40 now 80).  This doesn't effect the other rate limits we have in effect.