### PR TITLE
fix: mount svc account in a subpath under /tmp

### DIFF
--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -113,7 +113,7 @@ spec:
 
         {{ if .Values.galoy.api.firebaseNotifications.enabled }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: "/tmp/service-account.json"
+          value: "/tmp/firebase-service-account/service-account.json"
         {{ end }}
 
         {{ if .Values.galoy.api.probes.enabled }}
@@ -139,7 +139,7 @@ spec:
         volumeMounts:
         {{ if .Values.galoy.api.firebaseNotifications.enabled }}
         - name: firebase-notifications-service-account
-          mountPath: /tmp
+          mountPath: /tmp/firebase-service-account/
           readOnly: true
         {{ end }}
 


### PR DESCRIPTION
As part of #1389 , the mount path for the service account was set to `/tmp` which changed the `/tmp`'s permissions and made it a readonly path. This PR mounts the service account a level deeper to remedy this issue.