### PR TITLE
fix: fill loop creds with lnd data

### DIFF
--- a/charts/galoy/templates/_helpers.tpl
+++ b/charts/galoy/templates/_helpers.tpl
@@ -157,6 +157,17 @@ Return Galoy environment variables for LND 1 configuration
     secretKeyRef:
       name: {{ .Values.galoy.lnd1.loopCredentialsExistingSecret.name }}
       key: {{ .Values.galoy.lnd1.loopCredentialsExistingSecret.tls_key }}
+{{ else }}
+- name: LND1_LOOP_MACAROON
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.lnd1.credentialsExistingSecret.name }}
+      key: {{ .Values.galoy.lnd1.credentialsExistingSecret.macaroon_key }}
+- name: LND1_LOOP_TLS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.lnd1.credentialsExistingSecret.name }}
+      key: {{ .Values.galoy.lnd1.credentialsExistingSecret.tls_key }}
 {{ end }}
 {{- end -}}
 
@@ -192,6 +203,17 @@ Return Galoy environment variables for LND 2 configuration
     secretKeyRef:
       name: {{ .Values.galoy.lnd2.loopCredentialsExistingSecret.name }}
       key: {{ .Values.galoy.lnd2.loopCredentialsExistingSecret.tls_key }}
+{{ else }}
+- name: LND2_LOOP_MACAROON
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.lnd2.credentialsExistingSecret.name }}
+      key: {{ .Values.galoy.lnd2.credentialsExistingSecret.macaroon_key }}
+- name: LND2_LOOP_TLS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.lnd2.credentialsExistingSecret.name }}
+      key: {{ .Values.galoy.lnd2.credentialsExistingSecret.tls_key }}
 {{ end }}
 {{- end -}}
 


### PR DESCRIPTION
When using sigent Loop needs to be disabled, but the galoy API needs it's credentials for now.

This is a temporary solution as did not get to avoid  the errors in the backend yet: https://github.com/GaloyMoney/galoy/pull/1733 only discussed steps needed there with @nicktee.