### PR TITLE
refactor: galoy deps smoketest

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -74,6 +74,7 @@ groups:
 - name: galoy-deps
   jobs:
   - galoy-deps-testflight
+  - bump-galoy-deps-in-deployments
 - name: images
   jobs:
   - build-chain-dl-image
@@ -100,6 +101,7 @@ jobs:
 - #@ testflight_job("stablesats", "stablesats", stablesats_chart_vars())
 - #@ bump_in_deployments_job("stablesats")
 - #@ testflight_job("galoy-deps", "galoy-deps")
+- #@ bump_in_deployments_job("galoy-deps")
 
 - name: build-chain-dl-image
   serial: true

--- a/ci/testflight/galoy-deps/galoy-deps-values.yml.tmpl
+++ b/ci/testflight/galoy-deps/galoy-deps-values.yml.tmpl
@@ -1,0 +1,5 @@
+strimzi-kafka-operator:
+  watchNamespaces:
+%{ for namespace in watch_namespaces ~}
+  - "${namespace}"
+%{ endfor ~}


### PR DESCRIPTION
This PR removes the newly introduce kubectl plugin, and moves the topic creation to the smoketest script. A new watchNamespaces field needs to be set for the helm installation because the topic is being created in the smoketest namespace.