### PR TITLE
chore: update lnd docker images to v0.15.4-beta

### DIFF
--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lnd
 version: 0.3.7-dev
-appVersion: 0.15.3
+appVersion: 0.15.4
 description: LND helm chart
 keywords:
   - lnd

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -2,7 +2,7 @@ global:
   network: mainnet
 image:
   repository: lightninglabs/lnd
-  tag: v0.15.3-beta
+  tag: v0.15.4-beta
   pullPolicy: IfNotPresent
 sidecarImage:
   repository: us.gcr.io/galoy-org/lnd-sidecar

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM lightninglabs/lnd:v0.15.3-beta as lnd
+FROM lightninglabs/lnd:v0.15.4-beta as lnd
 FROM lightninglabs/loop:v0.20.1-beta as loop
 
 FROM alpine/k8s:1.21.5


### PR DESCRIPTION
Preemptive draft to rerun the tests as soon as the new LND release image becomes available at https://hub.docker.com/r/lightninglabs/lnd/tags.