### PR TITLE
ci: remove redundant topic deletion from script

### DIFF
--- a/ci/tasks/galoy-deps-smoketest.sh
+++ b/ci/tasks/galoy-deps-smoketest.sh
@@ -36,8 +36,6 @@ for i in {1..15}; do
   sleep 1
 done
 
-k -n $kafka_namespace delete kafkatopics.kafka.strimzi.io $kafka_topic
-
 if [[ "$success" != "true" ]]; then echo "Smoke test failed" && exit 1; fi;
 
 set -e


### PR DESCRIPTION
The topic will get deleted anyway when the namespace is deleted, so manual deletion is not necessary.