### PR TITLE
chore: adapt the dev env to the new kratos config

### DIFF
--- a/dev/auth/galoy-auth-dev-values.yml.tmpl
+++ b/dev/auth/galoy-auth-dev-values.yml.tmpl
@@ -1,0 +1,4 @@
+kratos:
+  kratos:
+    config:
+      dsn: "postgres://postgres:${postgres_password}@postgresql:5432/${postgres_database}?sslmode=disable"

--- a/dev/auth/main.tf
+++ b/dev/auth/main.tf
@@ -3,24 +3,17 @@ variable "name_prefix" {}
 locals {
   smoketest_namespace = "${var.name_prefix}-smoketest"
   auth_namespace      = "${var.name_prefix}-auth"
+
+  session_keys = "session-keys"
+
+  postgres_database = "auth_db"
+  postgres_password = "postgres"
 }
 
 resource "kubernetes_namespace" "auth" {
   metadata {
     name = local.auth_namespace
   }
-}
-
-resource "helm_release" "galoy_auth" {
-  name      = "galoy-auth"
-  chart     = "${path.module}/../../charts/galoy-auth"
-  namespace = kubernetes_namespace.auth.metadata[0].name
-
-  values = [
-    file("${path.module}/auth-values.yml")
-  ]
-
-  dependency_update = true
 }
 
 resource "kubernetes_secret" "galoy_auth_smoketest" {
@@ -32,4 +25,45 @@ resource "kubernetes_secret" "galoy_auth_smoketest" {
     kratos_admin_endpoint = "galoy-auth-kratos-admin.${local.auth_namespace}.svc.cluster.local"
     kratos_admin_port     = 80
   }
+}
+
+resource "kubernetes_secret" "auth_backend" {
+  metadata {
+    name      = "auth-backend"
+    namespace = local.auth_namespace
+  }
+  data = {
+    "session-keys" : local.session_keys
+  }
+}
+
+resource "helm_release" "galoy_auth" {
+  name      = "galoy-auth"
+  chart     = "${path.module}/../../charts/galoy-auth"
+  namespace = kubernetes_namespace.auth.metadata[0].name
+
+  values = [
+    templatefile("${path.module}/galoy-auth-dev-values.yml.tmpl", {
+      postgres_database : local.postgres_database
+      postgres_password : local.postgres_password
+    })
+  ]
+
+  dependency_update = true
+
+  depends_on = [helm_release.postgres]
+}
+
+resource "helm_release" "postgres" {
+  name       = "postgresql"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "postgresql"
+  namespace  = kubernetes_namespace.auth.metadata[0].name
+
+  values = [
+    templatefile("${path.module}/postgres-testflight-values.yml.tmpl", {
+      postgres_database : local.postgres_database
+      postgres_password : local.postgres_password
+    })
+  ]
 }

--- a/dev/auth/postgres-testflight-values.yml.tmpl
+++ b/dev/auth/postgres-testflight-values.yml.tmpl
@@ -1,0 +1,6 @@
+auth:
+  postgresPassword: ${postgres_password}
+  database: ${postgres_database}
+primary:
+  persistence:
+    enabled: false

--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -52,6 +52,11 @@ mongodb:
     enabled: false
   initDbScripts: {}
 
+postgresql:
+  primary:
+    persistence:
+      enabled: false
+
 redis:
   volumePermissions:
     enabled: true
@@ -62,6 +67,9 @@ redis:
       enabled: false
   metrics:
     enabled: false
+  auth:
+    existingSecret: "galoy-redis"
+    existingSecretPasswordKey: "redis-password"
 
 price:
   service:

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -84,7 +84,7 @@ resource "kubernetes_secret" "mongodb_creds" {
 
 resource "kubernetes_secret" "redis_creds" {
   metadata {
-    name      = "galoy-redis-pw"
+    name      = "galoy-redis"
     namespace = kubernetes_namespace.galoy.metadata[0].name
   }
 


### PR DESCRIPTION
Currently still getting the error when trying to log in with the api locally:
```
$ curl -k 'https://localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+59981730222","code":"111111"}}}'

{"errors":[{"message":"connect ECONNREFUSED ::1:4433","locations":[{"line":1,"column":43}],"path":["userLogin"],"code":"INTERNAL_SERVER_ERROR"}],"data":null}
```