### PR TITLE
refactor: allow dependencies to be disabled in deps chart

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: kube-monkey
   repository: https://asobti.github.io/kube-monkey/charts/repo
   version: 1.5.0
-digest: sha256:3a6ec7bde3a207846918c61c76cdee0dfde0329c69646229dfdae3cb37fafc2d
-generated: "2022-11-16T18:42:16.805733895+05:30"
+digest: sha256:a670ecd8373173dd9f370bbb101091cf78a125529bf3b8d02c8389de312ff0a2
+generated: "2022-11-17T14:50:26.269339821+05:30"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -23,7 +23,9 @@ dependencies:
   - name: strimzi-kafka-operator
     repository: https://strimzi.io/charts/
     version: 0.32.0
+    condition: strimzi-kafka-operator.enabled
   - name: kube-monkey
     alias: kubemonkey
     repository: https://asobti.github.io/kube-monkey/charts/repo
     version: 1.5.0
+    condition: kubemonkey.enabled

--- a/charts/galoy-deps/templates/kafka-cluster.yaml
+++ b/charts/galoy-deps/templates/kafka-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
-  name: {{include "galoy-deps.fullname" .}}-kafka
+  name: kafka
 spec:
   kafka:
     version: 3.2.3

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -2,10 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-nameOverride: ""
-fullnameOverride: ""
-
 strimzi-kafka-operator:
+  enabled: true
+  nameOverride: kafka
   watchNamespaces: []
 
-kubemonkey: {}
+kubemonkey:
+  enabled: true
+  fullnameOverride: kubemonkey

--- a/ci/testflight/galoy-deps/main.tf
+++ b/ci/testflight/galoy-deps/main.tf
@@ -36,7 +36,7 @@ resource "kubernetes_secret" "smoketest" {
     namespace = local.smoketest_namespace
   }
   data = {
-    kafka_broker_endpoint = "galoy-deps-kafka-kafka-brokers.${local.testflight_namespace}.svc.cluster.local"
+    kafka_broker_endpoint = "kafka-kafka-brokers.${local.testflight_namespace}.svc.cluster.local"
     kafka_broker_port     = 9092
     kafka_namespace       = local.testflight_namespace
     kafka_cluster         = "${helm_release.galoy_deps.metadata[0].name}-kafka"


### PR DESCRIPTION
This PR also overrides the subchart names so that the resources' names are less verbose