### PR TITLE
ci: fix dev smoketest by ordering deps installations

### DIFF
--- a/dev/galoy-deps/kafka.tf
+++ b/dev/galoy-deps/kafka.tf
@@ -25,4 +25,8 @@ resource "helm_release" "kafka" {
   ]
 
   dependency_update = true
+
+  depends_on = [
+    helm_release.otel
+  ]
 }

--- a/dev/galoy-deps/kubemonkey.tf
+++ b/dev/galoy-deps/kubemonkey.tf
@@ -31,4 +31,8 @@ resource "helm_release" "kubemonkey" {
   ]
 
   dependency_update = true
+
+  depends_on = [
+    helm_release.kafka
+  ]
 }


### PR DESCRIPTION
The dev smoketests have been failing because a race condition was introduced with the addition of the deps module. 

The problem is that we install the same chart - the deps chart - multiple times in the form of separate helm releases, each time with only one dependency chart enabled out of all. Terraform attempts these installations in parallel, but they all try to use the same directory to download the dependency charts to, leading to a race condition. Ordering the installation of the different helm releases within the deps module will fix the issue, with the tradeoff of slower test times.

Edit: The smoketest is still failing, but for a different reason now - the otel installation is in an in-between state: it's still present in 'galoy-infra/services' , but we have also added it to deps. This is causing a namespace clash. It will be removed from infra soon once it's verified to be working on staging inside deps.