### PR TITLE
feat: export lnd's TLS secrets as a k8s tls secret type

### DIFF
--- a/charts/lnd/Chart.lock
+++ b/charts/lnd/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.19
-digest: sha256:b4ff598f1a247a7d42db9e87c24ff35328829544e794294c12bb147d5d1efc49
-generated: "2022-11-15T17:06:55.266810345Z"
+digest: sha256:7f4c944794bcc39964a49eef6a4ecff4ceeb456957f4b0f47d2519935e7f6b78
+generated: "2022-12-17T01:59:28.469117336-05:00"

--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lnd
-version: 0.3.10-dev
+version: 0.3.11-dev
 appVersion: 0.15.4
 description: LND helm chart
 keywords:

--- a/charts/lnd/templates/export-secrets-configmap.yaml
+++ b/charts/lnd/templates/export-secrets-configmap.yaml
@@ -21,3 +21,8 @@ data:
     --from-literal=tls_base64=$TLS --from-file=/root/.lnd/tls.cert \
     --from-literal=admin_macaroon_base64=$MACAROON --from-file=macaroons \
     --dry-run=client -o yaml | kubectl apply -f -
+
+    kubectl create secret tls {{ include "lnd.fullname" . }}-internal-tls \
+    --cert=/root/.lnd/tls.cert \
+    --key=/root/.lnd/tls.key \
+    --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
The idea behind this is to have the ability to plug in the certificates to something like your ingress-controller which typically requires a standard `kubernetes.io/tls` secret type.

I do hope to hopefully manage certificates outside of LND once https://github.com/lightningnetwork/lnd/pull/6479 is implemented.

Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>