### PR TITLE
chore!: remove pg from lnd

### DIFF
--- a/charts/lnd/Chart.lock
+++ b/charts/lnd/Chart.lock
@@ -8,8 +8,5 @@ dependencies:
 - name: loopserver
   repository: ""
   version: x.x.x
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.1.19
-digest: sha256:b4ff598f1a247a7d42db9e87c24ff35328829544e794294c12bb147d5d1efc49
-generated: "2022-11-15T17:06:55.266810345Z"
+digest: sha256:6fad3626323bc5a24734921ffa7588293b8178847d0ff994dc766e2c70e3a378
+generated: "2022-12-20T00:29:00.305903327+05:30"

--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -21,7 +21,3 @@ dependencies:
   - name: loopserver
     version: x.x.x
     condition: loopserver.enabled
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 11.1.19
-    condition: postgresql.enabled

--- a/charts/lnd/templates/statefulset.yaml
+++ b/charts/lnd/templates/statefulset.yaml
@@ -49,12 +49,6 @@ spec:
           - |
             cat <<EOF > /root/.lnd/lnd.conf
             bitcoind.rpcpass=$(cat /rpcpassword/password)
-          {{- if eq .Values.lnd.db.backend "postgres" }}
-            db.backend=postgres
-            db.postgres.dsn=$(cat /lnd-pg-uri/uri)
-            db.postgres.timeout=0
-            db.postgres.maxconnections=21
-          {{- end}}
             $(cat /configmap/lnd.conf)
             EOF
           volumeMounts:
@@ -64,10 +58,6 @@ spec:
               mountPath: /root/.lnd/
             - name: rpcpassword
               mountPath: /rpcpassword
-            {{- if eq .Values.lnd.db.backend "postgres" }}
-            - name: lnd-pg-uri
-              mountPath: /lnd-pg-uri
-            {{- end}}
       containers:
         {{- if and (ne .Values.global.network "regtest") .Values.autoGenerateSeed.enabled }}
         - name: init-wallet
@@ -218,11 +208,6 @@ spec:
         - name: rpcpassword
           secret:
             secretName: {{ .Values.bitcoindRpcPassSecretName }}
-        {{- if eq .Values.lnd.db.backend "postgres" }}
-        - name: lnd-pg-uri
-          secret:
-            secretName: {{ .Values.lnd.db.config.secret }}
-        {{- end}}
         - name: configmap
           configMap:
             name: {{ include "lnd.fullname" . }}

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -98,14 +98,3 @@ rbac:
   create: true
 autoGenerateSeed:
   enabled: false
-postgresql:
-  enabled: false
-  auth:
-    database: lnd
-    existingSecret: postgres-creds
-lnd:
-  db:
-    backend: bbolt
-    config:
-      # This secret should contain `uri` as the key
-      secret: postgres-creds

--- a/ci/testflight/lnd/main.tf
+++ b/ci/testflight/lnd/main.tf
@@ -58,18 +58,6 @@ resource "kubernetes_secret" "smoketest" {
   }
 }
 
-resource "kubernetes_secret" "lnd_pg_pass" {
-  metadata {
-    name      = "postgres-creds"
-    namespace = kubernetes_namespace.testflight.metadata[0].name
-  }
-
-  data = {
-    uri                 = "postgres://postgres:password@lnd1-postgresql:5432/lnd"
-    "postgres-password" = "password"
-  }
-}
-
 resource "helm_release" "lnd1" {
   name       = "lnd1"
   chart      = "${path.module}/chart"

--- a/dev/bitcoin/lnd1.tf
+++ b/dev/bitcoin/lnd1.tf
@@ -1,15 +1,3 @@
-resource "kubernetes_secret" "lnd_pg_pass" {
-  metadata {
-    name      = "postgres-creds"
-    namespace = kubernetes_namespace.bitcoin.metadata[0].name
-  }
-
-  data = {
-    uri                 = "postgres://postgres:password@lnd1-postgresql:5432/lnd"
-    "postgres-password" = "password"
-  }
-}
-
 resource "helm_release" "lnd" {
   name      = "lnd1"
   chart     = "${path.module}/../../charts/lnd"


### PR DESCRIPTION
LND on postgres is far from production ready. We want to keep the chart clean and only allow configurations that run well in prod, so this PR removes postgres support from the chart.