### PR TITLE
chore: update rtl to v0.13.3

### DIFF
--- a/charts/rtl/Chart.yaml
+++ b/charts/rtl/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7-dev
+version: 0.1.8-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.10.2
+appVersion: 0.13.3
 engine: gotpl
 dependencies:
   - name: common

--- a/charts/rtl/templates/configmap_and_secret.yaml
+++ b/charts/rtl/templates/configmap_and_secret.yaml
@@ -26,7 +26,7 @@ data:
           "lnNode": "Node {{ $c }}",
           "lnImplementation": "LND",
           "Authentication": {
-            "macaroonPath": "/lnd{{ $c }}/rpc",
+            "macaroonPath": "/RTL/data/lnd{{ $c }}/rpc",
             "configPath": ""
           },
           "Settings": {
@@ -36,7 +36,7 @@ data:
             "lnServerUrl": "https://{{ .url }}:8080",
             "enableLogging": true,
             "fiatConversion": true,
-            "channelBackupPath": "/home/node/node{{ $c }}backup"
+            "channelBackupPath": "/RTL/data/lnd{{ $c }}backup"
           }
         }{{- if ne (len $.Values.lnds) $c}},{{ end }}
         {{- end }}

--- a/charts/rtl/templates/deployment.yaml
+++ b/charts/rtl/templates/deployment.yaml
@@ -32,12 +32,30 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: copy-rtl-config
+          image: busybox
+          command:
+          - 'sh'
+          - '-c'
+          - |
+            cp /RTL/RTL-Config.json /RTL/data/RTL-Config.json
+            chown 1000:1000 /RTL/data/RTL-Config.json
+          volumeMounts:
+            - name: rtl-conf
+              mountPath: "/RTL/RTL-Config.json"
+              subPath: "RTL-Config.json"
+            - name: data
+              mountPath: /RTL/data
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: RTL_CONFIG_PATH
+              value: /RTL/data     
           ports:
             - name: http
               containerPort: {{.Values.service.port}}
@@ -53,17 +71,18 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: rtl-conf
-              mountPath: "/RTL/RTL-Config.json"
-              subPath: "RTL-Config.json"
+            - name: data
+              mountPath: /RTL/data
             {{- $c := 0 | int }}
             {{- range .Values.lnds }}
             {{- $c = add1 $c }}
             - name: "lnd{{ $c }}-rpc"
-              mountPath: "/lnd{{ $c }}/rpc"
+              mountPath: "/RTL/data/lnd{{ $c }}/rpc"
               readOnly: true
             {{- end }}
       volumes:
+          - name: data
+            emptyDir: {}
           - name: rtl-conf
             configMap:
               name: {{ include "rtl.fullname" . }}

--- a/charts/rtl/values.yaml
+++ b/charts/rtl/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: shahanafarooqui/rtl
-  tag: 0.10.2
+  tag: 0.13.3
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
This updates the rtl chart to the latest version. It needed some changes since newer rtl versions need write-access to the config file.
Which is why I added an init-container which copies over the configuration and sets write permissions for the node-user.
With this the folder /RTL/data will hold the config, lnd-macaroons, lnd-channelbackups & lnd logs.