### PR TITLE
ci: use unique name for kubemonkey in testflight

### DIFF
--- a/ci/testflight/galoy-deps/main.tf
+++ b/ci/testflight/galoy-deps/main.tf
@@ -6,12 +6,13 @@ locals {
   cluster_location = "us-east1"
   gcp_project      = "galoy-staging"
 
-  testflight_namespace = var.testflight_namespace
-  smoketest_namespace  = "galoy-staging-smoketest"
-  smoketest_kubeconfig = var.smoketest_kubeconfig
-  smoketest_name       = "smoketest"
-  service_name         = "${local.testflight_namespace}-ingress"
-  jaeger_host          = "galoy-deps-opentelemetry-collector"
+  testflight_namespace         = var.testflight_namespace
+  smoketest_namespace          = "galoy-staging-smoketest"
+  smoketest_kubeconfig         = var.smoketest_kubeconfig
+  smoketest_name               = "smoketest"
+  service_name                 = "${local.testflight_namespace}-ingress"
+  jaeger_host                  = "galoy-deps-opentelemetry-collector"
+  kubemonkey_fullname_override = local.testflight_namespace
 }
 
 resource "kubernetes_namespace" "testflight" {
@@ -29,6 +30,7 @@ resource "helm_release" "galoy_deps" {
     templatefile("${path.module}/testflight-values.yml.tmpl", {
       service_name : local.service_name
       jaeger_host : local.jaeger_host
+      kubemonkey_fullname_override : local.kubemonkey_fullname_override
     })
   ]
 

--- a/ci/testflight/galoy-deps/testflight-values.yml.tmpl
+++ b/ci/testflight/galoy-deps/testflight-values.yml.tmpl
@@ -1,5 +1,7 @@
 strimzi-kafka-operator:
   createGlobalResources: false
+kubemonkey:
+  fullnameOverride: ${kubemonkey_fullname_override}
 cert-manager:
   installCRDs: false
 ingress-nginx:


### PR DESCRIPTION
v1.5.2 of the kubemoney chart [removed](https://github.com/asobti/kube-monkey/pull/244) the option to disable rbac, and so testflight fails due to the clash with clusterwide resources from the staging deployment of kubemonkey.

Overriding the fullname with the testflight namespace var will make the clusterwide resources in testflight also unique, fixing the problem.