### PR TITLE
chore: update otel-collector + run as daemonset

### DIFF
--- a/charts/galoy-deps/Chart.lock
+++ b/charts/galoy-deps/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 1.5.2
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.43.5
-digest: sha256:72065190bb1870fbb201bd2d7827bdddb47fa54654e09e43f46bba52bd696030
-generated: "2023-01-11T18:04:28.008058329Z"
+  version: 0.44.1
+digest: sha256:bb78189a94b06f97e695405438b38a1e23c87e8e1efcaf44a3914750a6c99d2f
+generated: "2023-01-13T09:57:14.373699+01:00"

--- a/charts/galoy-deps/Chart.yaml
+++ b/charts/galoy-deps/Chart.yaml
@@ -39,5 +39,5 @@ dependencies:
     condition: kubemonkey.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.43.5
+    version: 0.44.1
     condition: opentelemetry-collector.enabled

--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -13,7 +13,7 @@ kubemonkey:
 
 opentelemetry-collector:
   enabled: true
-  mode: deployment
+  mode: daemonset
   config:
     exporters:
       logging: {}
@@ -73,7 +73,7 @@ opentelemetry-collector:
       # If set to null, will be overridden with values based on k8s resource limits
       memory_limiter: null
       resourcedetection:
-        detectors: [env, gke]
+        detectors: [env, gcp]
         timeout: 5s
         override: false
       k8sattributes:

--- a/dev/galoy-deps/otel.tf
+++ b/dev/galoy-deps/otel.tf
@@ -1,5 +1,5 @@
 locals {
-  otel_namespace = "${var.name_prefix}-deps-otel"
+  otel_namespace = "${var.name_prefix}-otel"
 }
 
 resource "kubernetes_namespace" "otel" {


### PR DESCRIPTION
Fixes the breaking change causing https://github.com/GaloyMoney/charts/pull/2376 to fail.
Also switches the deployment to daemonset mode to have a collector on each mode.