### PR TITLE
chore: update lnd version to v0.15.5-beta

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -2,7 +2,7 @@ global:
   network: mainnet
 image:
   repository: lightninglabs/lnd
-  tag: v0.15.4-beta
+  tag: v0.15.5-beta
   pullPolicy: IfNotPresent
 sidecarImage:
   repository: us.gcr.io/galoy-org/lnd-sidecar

--- a/images/lnd-sidecar/Dockerfile
+++ b/images/lnd-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM lightninglabs/lnd:v0.15.4-beta as lnd
+FROM lightninglabs/lnd:v0.15.5-beta as lnd
 FROM lightninglabs/loop:v0.20.1-beta as loop
 
 FROM alpine/k8s:1.23.14


### PR DESCRIPTION
Update to the latest lnd version.

Before merge check tests are passing https://github.com/GaloyMoney/galoy/pull/2199