### PR TITLE
chore: add the kratos and oathkeeper config to the default values

### DIFF
--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -721,7 +721,7 @@ kratos:
 
       version: v0.11.0
 
-      dsn: memory
+      dsn: postgresql://kratos-pg:kratos-pg@postgresql/kratos-pg
 
       serve:
         public:

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -715,23 +715,170 @@ kratos:
     automigration:
       enabled: true
     config:
-      session:
-        lifespan: "720h" # 1 month
-        earliest_possible_extend: "96h" # 4 days
-      identity:
-        schemas:
-          - id: email
-            url: file:///etc/config/identity.schema.json
-        default_schema_id: email
-      selfservice:
-        default_browser_return_url: http://127.0.0.1:4002/
-      courier:
-        smtp:
-          connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true
-      dsn: memory
       secrets:
         default:
           - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
+
+      version: v0.11.0
+
+      dsn: memory
+
+      serve:
+        public:
+          base_url: http://127.0.0.1:4433/
+          cors:
+            enabled: true
+            allow_credentials: true
+            allowed_origins:
+              - http://127.0.0.1:4433
+              - http://0.0.0.0:4434
+              - http://localhost:3000
+              - http://127.0.0.1:3000
+            allowed_methods:
+              - POST
+              - GET
+              - PUT
+              - PATCH
+              - DELETE
+            allowed_headers:
+              - Authorization
+              - Cookie
+              - Content-Type
+              - X-Session-Token
+            exposed_headers:
+              - Content-Type
+              - Set-Cookie
+            debug: true
+
+        admin:
+          base_url: http://0.0.0.0:4434/
+
+      selfservice:
+        default_browser_return_url: http://localhost:3000/
+        allowed_return_urls:
+          - http://127.0.0.1:4002/
+          - http://localhost:3000/
+      
+        methods:
+          oidc:
+            enabled: false
+          webauthn:
+            enabled: false
+          totp:
+            enabled: true
+          password:
+            enabled: true
+      
+          code:
+            enabled: true
+            config:
+              # Defines how long the verification or the recovery code is valid for (default 1h)
+              lifespan: 15m
+      
+        flows:
+          error:
+            ui_url: http://127.0.0.1:4002/error
+      
+          settings:
+            ui_url: http://127.0.0.1:4002/settings
+            privileged_session_max_age: 15m
+      
+            required_aal: aal1
+      
+            after:
+              profile:
+                hooks:
+                  - hook: web_hook
+                    config:
+                      # url: http://e2e-tests:4002/auth/after_settings_hooks
+                      url: http://invalid-because-we-dont-want-profile-to-be-updated
+                      method: POST
+                      body: file:///home/ory/body.jsonnet
+                      auth:
+                        type: api_key
+                        config:
+                          name: Authorization
+                          value: The-Value-of-My-Key
+                          in: header
+      
+          recovery:
+            enabled: true
+            ui_url: http://127.0.0.1:4002/recovery
+      
+          verification:
+            use: code # Defines which method is used, one of 'code' or 'link'.
+            enabled: true
+      
+          logout:
+            after:
+              default_browser_return_url: http://127.0.0.1:4002/login
+      
+          login:
+            ui_url: http://localhost:3000/login
+            lifespan: 10m
+      
+            # this below make phone authentication fails even if there is no email in the schema
+            # after:
+            #   password:
+            #     hooks:
+            #     - hook: require_verified_address
+      
+          registration:
+            lifespan: 10m
+            ui_url: http://localhost:3000/register
+            after:
+              password:
+                hooks:
+                  - hook: web_hook
+                    config:
+                      url: http://e2e-tests:4012/kratos/registration
+                      method: POST
+                      can_interrupt: true
+                      body: file:///home/ory/body.jsonnet # TODO: use a base64 encoding instead
+                      auth:
+                        type: api_key
+                        config:
+                          name: Authorization
+                          value: The-Value-of-My-Key
+                          in: header
+                  - hook: session
+      
+      log:
+        level: debug
+        format: json
+        leak_sensitive_values: true
+
+      secrets:
+        cookie:
+          - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
+        cipher:
+          - 32-LONG-SECRET-NOT-SECURE-AT-ALL
+
+      ciphers:
+        algorithm: xchacha20-poly1305
+
+      hashers:
+        algorithm: bcrypt
+        bcrypt:
+          cost: 8
+
+      identity:
+        default_schema_id: email
+        schemas:
+          - id: email
+            url: file:///etc/config/identity.schema.json
+
+      courier:
+        smtp:
+          connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true
+
+      session:
+        lifespan: "720h" # 1 month
+        earliest_possible_extend: "96h" # 4 days
+
+        whoami:
+          required_aal: aal1
+
     identitySchemas:
       "identity.schema.json": |
         {

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -673,6 +673,13 @@ oathkeeper:
           },
           "authenticators": [
            {
+            "handler": "cookie_session",
+            "config": {
+               "check_session_url": "http://kratos:4433/sessions/whoami",
+               "preserve_path": true,
+               "preserve_query": true,
+               "subject_from": "identity.id"
+             },      
              "handler": "bearer_token",
              "config": {
                "check_session_url": "http://api:4002/auth/validatetoken",

--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -66,10 +66,11 @@ redis:
 price:
   service:
     type: NodePort
-  postgresql:
-    primary:
-      persistence:
-        enabled: false
+
+postgresql:
+  primary:
+    persistence:
+      enabled: false
 
 oathkeeper:
   secret:

--- a/dev/galoy/galoy-signet-values.yml
+++ b/dev/galoy/galoy-signet-values.yml
@@ -67,10 +67,11 @@ redis:
 price:
   service:
     type: NodePort
-  postgresql:
-    primary:
-      persistence:
-        enabled: true
+
+postgresql:
+  primary:
+    persistence:
+      enabled: true
 
 secrets:
   create: false

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -244,6 +244,18 @@ resource "kubernetes_secret" "oathkeeper" {
   }
 }
 
+
+resource "helm_release" "postgresql" {
+  name       = "postgresql"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "postgresql"
+  namespace  = kubernetes_namespace.galoy.metadata[0].name
+
+  values = [
+    file("${path.module}/postgresql-values.yml")
+  ]
+}
+
 resource "helm_release" "galoy" {
   name      = "galoy"
   chart     = "${path.module}/../../charts/galoy"
@@ -261,7 +273,8 @@ resource "helm_release" "galoy" {
     kubernetes_secret.lnd2_credentials,
     kubernetes_secret.loop2_credentials,
     kubernetes_secret.lnd2_pubkey,
-    kubernetes_secret.price_history_postgres_creds
+    kubernetes_secret.price_history_postgres_creds,
+    helm_release.postgresql
   ]
 
   dependency_update = true

--- a/dev/galoy/postgresql-values.yml
+++ b/dev/galoy/postgresql-values.yml
@@ -1,0 +1,10 @@
+# Settings from:
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+
+auth:
+  username: kratos-pg
+  password: kratos-pg
+  database: kratos-pg
+
+persistence:
+  enabled: false


### PR DESCRIPTION
The Oathkeeper changes are based on:
https://github.com/GaloyMoney/galoy/pull/2103/files#diff-f2d3bed1938639bd048c1629be6fe575621bc4eb0cef967ab52d10f6ca96369e

Kratos:
https://github.com/GaloyMoney/galoy/blob/6f3bcdbb4bc24beb3546a5ade90a5384cc707072/dev/ory/kratos.yml

except:
`schemas`
`dsn`

A new postgresql instance is added to stand up before kratos and the `dsn` is configured accordingly.