### PR TITLE
ci: make dev setup faster

### DIFF
--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -43,8 +43,6 @@ galoy:
 
 mongodb:
   architecture: standalone
-  volumePermissions:
-    enabled: true
   persistence:
     enabled: false
   replicaCount: 1
@@ -53,8 +51,6 @@ mongodb:
   initDbScripts: {}
 
 redis:
-  volumePermissions:
-    enabled: true
   replica:
     replicaCount: 1
   master:

--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -62,6 +62,8 @@ redis:
       enabled: false
   metrics:
     enabled: false
+  sentinel:
+    getMasterTimeout: 5
 
 price:
   service:


### PR DESCRIPTION
By reducing the timeout from the default of 220 seconds to 5 seconds, the time to standup the galoy module in dev was cut by half in my machine. There are no apparent risks to doing this since we use only 1 replica in the dev setup anyway, so we don't run the risk of multiple nodes becoming masters simultaneously as a result of the timeout tweaking.

