### PR TITLE
fix: don't connect to postgres in galoy-testflight

### DIFF
--- a/ci/testflight/galoy/testflight-values.yml
+++ b/ci/testflight/galoy/testflight-values.yml
@@ -78,3 +78,9 @@ secrets:
 
 loop:
   enabled: false
+
+kratos:
+  kratos:
+    config:
+      # do not connect to postgres in testflight (creates an in memory sqlite db instead)
+      dsn: memory


### PR DESCRIPTION
only changing the dsn value for the galoy-testflight