### PR TITLE
chore: allow GET calls to galoy-pay for ln address

### DIFF
--- a/charts/galoy-pay/templates/ingress.yaml
+++ b/charts/galoy-pay/templates/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-issuer
+    nginx.ingress.kubernetes.io/enable-cors: "true"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Referring to the config at https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#enable-cors

>To enable Cross-Origin Resource Sharing (CORS) in an Ingress rule, add the annotation nginx.ingress.kubernetes.io/enable-cors: "true". This will add a section in the server location enabling this functionality.

>CORS can be controlled with the following annotations:
nginx.ingress.kubernetes.io/cors-allow-methods: Controls which methods are accepted.
This is a multi-valued field, separated by ',' and accepts only letters (upper and lower case).
Default: GET, PUT, POST, DELETE, PATCH, OPTIONS
Example: nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"

>nginx.ingress.kubernetes.io/cors-allow-origin: Controls what's the accepted Origin for CORS.
This is a multi-valued field, separated by ','. It must follow this format: http(s)://origin-site.com or http(s)://origin-site.com:port
Default: *