### PR TITLE
chore: specify the namespace for the kratos pg

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -15,6 +15,7 @@ locals {
 
   testflight_api_host = "galoy-oathkeeper-proxy.${local.testflight_namespace}.svc.cluster.local"
   kratos_admin_host   = "galoy-kratos-admin.${local.testflight_namespace}.svc.cluster.local"
+  kratos_pg_host      = "postgresql.${local.testflight_namespace}.svc.cluster.local"
 
   postgres_database = "price-history"
   postgres_username = "price-history"
@@ -350,6 +351,7 @@ resource "helm_release" "galoy" {
     templatefile("${path.module}/testflight-values.yml.tmpl", {
       bankowner_phone : local.bankowner_phone,
       bankowner_code : local.bankowner_code,
+      kratos_pg_host : local.kratos_pg_host,
       kratos_callback_api_key : random_password.kratos_callback_api_key.result
     }),
   file("${path.module}/testflight-values.yml")]

--- a/ci/testflight/galoy/testflight-values.yml.tmpl
+++ b/ci/testflight/galoy/testflight-values.yml.tmpl
@@ -30,6 +30,7 @@ galoy:
 kratos:
   kratos:
     config:
+      dsn: postgresql://kratos-pg:kratos-pg@${kratos_pg_host}/kratos-pg
       selfservice:
         flows:
           settings:

--- a/dev/galoy/galoy-values.yml.tmpl
+++ b/dev/galoy/galoy-values.yml.tmpl
@@ -10,6 +10,7 @@ galoy:
 kratos:
   kratos:
     config:
+      dsn: postgresql://kratos-pg:kratos-pg@${kratos_pg_host}/kratos-pg 
       selfservice:
         flows:
           settings:

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -14,6 +14,7 @@ locals {
   postgres_password = "price-history"
 
   galoy-oathkeeper-proxy-host = "galoy-oathkeeper-proxy.${local.galoy_namespace}.svc.cluster.local"
+  kratos_pg_host              = "postgresql.${local.galoy_namespace}.svc.cluster.local"
 
   bankowner_phone = "+59981730222"
   bankowner_code  = "111111"
@@ -287,6 +288,7 @@ resource "helm_release" "galoy" {
     templatefile("${path.module}/galoy-values.yml.tmpl", {
       bankowner_phone : local.bankowner_phone,
       bankowner_code : local.bankowner_code,
+      kratos_pg_host : local.kratos_pg_host,
       kratos_callback_api_key : random_password.kratos_callback_api_key.result
     }),
     file("${path.module}/galoy-${var.bitcoin_network}-values.yml")


### PR DESCRIPTION
To avoid the possibility of kratos connecting to an other existing postgres instance.
Related to #2626

The same changes are done for dev as for testflight.