### PR TITLE
chore: creating dedicated websocket server

### DIFF
--- a/charts/galoy/templates/_helpers.tpl
+++ b/charts/galoy/templates/_helpers.tpl
@@ -23,6 +23,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified websocket name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "galoy.websocket.fullname" -}}
+{{- default "websocket" .Values.galoy.websocket.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified exporter name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/galoy/templates/websocket-deployment.yaml
+++ b/charts/galoy/templates/websocket-deployment.yaml
@@ -124,10 +124,9 @@ spec:
           value: "/tmp/firebase-service-account/service-account.json"
         {{ end }}
 
-        {{ if .Values.galoy.api.probes.enabled }}
+        {{ if .Values.galoy.websocket.probes.enabled }}
         livenessProbe:
-          httpGet:
-            path: /healthz
+          tcpSocket:
             port: {{ .Values.galoy.websocket.port }}
           initialDelaySeconds: {{ .Values.galoy.websocket.probes.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.galoy.websocket.probes.liveness.periodSeconds }}
@@ -135,8 +134,7 @@ spec:
           timeoutSeconds: {{ .Values.galoy.websocket.probes.liveness.timeoutSeconds }}
 
         readinessProbe:
-          httpGet:
-            path: /healthz
+          tcpSocket:
             port: {{ .Values.galoy.websocket.port }}
           initialDelaySeconds: {{ .Values.galoy.websocket.probes.readiness.initialDelaySeconds }}
           failureThreshold: {{ .Values.galoy.websocket.probes.readiness.failureThreshold }}

--- a/charts/galoy/templates/websocket-deployment.yaml
+++ b/charts/galoy/templates/websocket-deployment.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+
+metadata:
+  name: {{ template "galoy.websocket.fullname" . }}
+  labels:
+    app: {{ template "galoy.websocket.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: {{ template "galoy.websocket.fullname" . }}
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+
+spec:
+
+  replicas: {{ .Values.galoy.websocket.replicas }}
+
+  selector:
+    matchLabels:
+      app: {{ template "galoy.websocket.fullname" . }}
+
+  template:
+
+    metadata:
+      name: {{ template "galoy.websocket.fullname" . }}
+      labels:
+        app: {{ template "galoy.websocket.fullname" . }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: {{ template "galoy.websocket.fullname" . }}
+        allow-to-bitcoind: "true"
+
+    spec:
+      serviceAccountName: {{ template "galoy.name" . }}
+
+      initContainers:
+      - name: wait-for-mongodb-migrate
+        image: "groundnuty/k8s-wait-for:v1.5.1"
+        args:
+        - job-wr
+        - {{ template "galoy.migration.jobname" . }}
+
+      containers:
+      - name: websocket
+        image: "{{ .Values.galoy.images.websocket.repository }}@{{ .Values.galoy.images.websocket.digest }}"
+        args:
+        - "-r"
+        - "/app/lib/services/tracing.js"
+        - "lib/servers/ws-server.js"
+
+        resources:
+          requests:
+            cpu: 100m
+          limits:
+            cpu: 1000m
+
+        ports:
+        - name: http
+          containerPort: {{ .Values.galoy.websocket.port }}
+          protocol: TCP
+
+        env:
+        - name: HELMREVISION
+          value: {{ .Release.Revision | quote }}
+        - name: NODE_ENV
+          value: "production"
+        - name: LOGLEVEL
+          value: {{ .Values.galoy.websocket.logLevel | quote }}
+
+        - name: NETWORK
+          value: {{ .Values.galoy.network }}
+        - name: GALOY_API_PORT
+          value: {{ .Values.galoy.api.port | quote }}
+        - name: GALOY_ADMIN_PORT
+          value: {{ .Values.galoy.admin.port | quote }}
+        - name: WEBSOCKET_PORT
+          value: {{ .Values.galoy.websocket.port | quote }}
+
+        - name: JAEGER_HOST
+          value: {{ .Values.tracing.jaegerHost | quote }}
+        - name: TRACING_SERVICE_NAME
+          value: "{{ .Values.tracing.prefix }}-{{ template "galoy.websocket.fullname" . }}"
+
+{{/* Databases */}}
+{{ include "galoy.mongodb.env" . | indent 8 }}
+{{ include "galoy.redis.env" . | indent 8 }}
+
+{{/* Bitcoin/LND */}}
+{{ include "galoy.bitcoind.env" . | indent 8 }}
+{{ include "galoy.lnd1.env" . | indent 8 }}
+{{ include "galoy.lnd2.env" . | indent 8 }}
+
+{{/* API Specifics */}}
+{{ include "galoy.twilio.env" . | indent 8 }}
+{{ include "galoy.geetest.env" . | indent 8 }}
+{{ include "galoy.jwt.env" . | indent 8 }}
+
+        - name: KRATOS_MASTER_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.kratos.existingSecret.name }}
+              key: {{ .Values.galoy.kratos.existingSecret.master_user_password }}
+        - name: KRATOS_CALLBACK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.kratos.existingSecret.name }}
+              key: {{ .Values.galoy.kratos.existingSecret.callback_api_key }}
+
+        - name: PRICE_HISTORY_HOST
+          value: {{ .Values.price.host | quote }}
+        - name: PRICE_HISTORY_PORT
+          value: {{ .Values.price.port | quote }}
+
+        - name: PRICE_SERVER_HOST
+          value: {{ .Values.galoy.dealer.host | quote }}
+        - name: PRICE_SERVER_PORT
+          value: {{ .Values.galoy.dealer.port | quote }}
+
+        {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/tmp/firebase-service-account/service-account.json"
+        {{ end }}
+
+        {{ if .Values.galoy.api.probes.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.galoy.websocket.port }}
+          initialDelaySeconds: {{ .Values.galoy.websocket.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.galoy.websocket.probes.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.galoy.websocket.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.galoy.websocket.probes.liveness.timeoutSeconds }}
+
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.galoy.websocket.port }}
+          initialDelaySeconds: {{ .Values.galoy.websocket.probes.readiness.initialDelaySeconds }}
+          failureThreshold: {{ .Values.galoy.websocket.probes.readiness.failureThreshold }}
+          successThreshold: {{ .Values.galoy.websocket.probes.readiness.successThreshold }}
+          timeoutSeconds: {{ .Values.galoy.websocket.probes.readiness.timeoutSeconds }}
+        {{ end }}
+
+        volumeMounts:
+        {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+        - name: firebase-notifications-service-account
+          mountPath: /tmp/firebase-service-account/
+          readOnly: true
+        {{ end }}
+
+        - name: custom-yaml
+          mountPath: "/var/yaml/"
+      volumes:
+      {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+      - name: firebase-notifications-service-account
+        secret:
+          secretName: {{ .Values.galoy.api.firebaseNotifications.existingSecret.name }}
+          items:
+          - key: {{ .Values.galoy.api.firebaseNotifications.existingSecret.key }}
+            path: service-account.json
+      {{ end }}
+
+      - name: custom-yaml
+        secret:
+          secretName: "{{ template "galoy.config.name" . }}"

--- a/charts/galoy/templates/websocket-service.yaml
+++ b/charts/galoy/templates/websocket-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+
+metadata:
+  name: {{ template "galoy.websocket.fullname" . }}
+  labels:
+    app: {{ template "galoy.websocket.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  type: {{ .Values.galoy.websocket.serviceType }}
+  ports:
+    - port: {{ .Values.galoy.websocket.port }}
+      targetPort: {{ .Values.galoy.websocket.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "galoy.websocket.fullname" . }}

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -48,6 +48,19 @@ galoy:
       ## Reference for timestamping the corresponding docker image and used by internal CI.
       ##
       git_ref: "b81cd57"
+    ## Galoy Websocket Application Image details
+    ##
+    websocket:
+      ## Has the websocket server
+      ##
+      repository: us.gcr.io/galoy-org/galoy-app-websocket
+      ## Digest of the image
+      ##
+      digest: "sha256:f1a1a586e15150e66cd50f4287689baabcaa529ed67b3853b873a9783bb5cf5a"
+      ## Not used by Helm, just used to ref to the source https://github.com/GaloyMoney/galoy.git
+      ## Reference for timestamping the corresponding docker image and used by internal CI.
+      ##
+      git_ref: "b81cd57"
     ## Galoy Application MongoDB Migration Image details
     ##
     mongodbMigrate:
@@ -297,6 +310,60 @@ galoy:
         timeoutSeconds: 1
   balanceNotificationCron:
     enabled: false
+  ## Configuration values for Galoy Websocket components.
+  ##
+  websocket:
+    ## Override the components name (defaults to websocket).
+    ##
+    nameOverride:
+    ## Number of replicas.
+    ##
+    replicas: 1
+    ## Log Level
+    ##
+    logLevel: debug
+    ## Port on which Admin API Server is running
+    ##
+    port: 4000
+    ## Service type
+    ##
+    serviceType: ClusterIP
+    ## Ingress configuration.
+    ## Ref: https://kubernetes.io/docs/user-guide/ingress/
+    ##
+    ingress:
+      ## Enable Ingress.
+      ##
+      enabled: false
+      ## Ingress Host
+      ##
+      host: websocket.staging.galoy.io
+      ## Cluster Issuer (Default: LetsEncrypt Certificate Isser defined at galoy-infra)
+      ## Read More: https://cert-manager.io/docs/usage/ingress/
+      ##
+      clusterIssuer: letsencrypt-issuer
+      ## TLS Secret Name
+      ##
+      tlsSecretName: websocket-tls
+    ## Liveness/Readiness Probes Configuration
+    ## Determines if pod is healthy or if it should be killed.
+    ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+    ##
+    probes:
+      ## Enable/disable Admin API probes for healthcheck
+      enabled: true
+      ## If pod is starting up/healthy
+      liveness:
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 5
+        timeoutSeconds: 1
+      ## When to expose the pod to the service
+      readiness:
+        initialDelaySeconds: 5
+        failureThreshold: 5
+        successThreshold: 2
+        timeoutSeconds: 1
   ## Kratos
   kratos:
     existingSecret:

--- a/dev/galoy/galoy-regtest-values.yml
+++ b/dev/galoy/galoy-regtest-values.yml
@@ -56,6 +56,21 @@ galoy:
             port:
               number: 4001
 
+  websocket:
+    ingress:
+      enabled: true
+      host: localhost
+      annotations:
+        nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      extraPaths:
+      - path: /(graphql|kratos|browser|healthz|metrics|auth)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: websocket
+            port:
+              number: 4000
+
 mongodb:
   architecture: standalone
   persistence:


### PR DESCRIPTION
This PR makes the new dedicated websocket server ws://localhost:4000 run in the charts environment.

Todo:
- [x] Make livenessProbe and readinessProbe work with websockets
- [x] Remove custom docker image (use ci gcr)
- [x] Merge after https://github.com/GaloyMoney/galoy/pull/2427
- [ ] how to expose publicly (ingress, oathkeeper?)