### PR TITLE
revert: prometheus chart upgrade #2758

### DIFF
--- a/charts/monitoring/Chart.lock
+++ b/charts/monitoring/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 6.52.4
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 20.0.0
-digest: sha256:b96be334069e8de95dafe53d59085de2635cebe6eaf49cf01c18f4356a1a8cf8
-generated: "2023-03-21T13:49:50.779508491Z"
+  version: 19.7.2
+digest: sha256:9b527f672956be5aab6e22fa97817345fcc6bb67de879ad951fb67c5142c9000
+generated: "2023-03-16T13:50:07.711954567Z"

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -24,4 +24,4 @@ dependencies:
     version: 6.52.4
   - name: prometheus
     repository: https://prometheus-community.github.io/helm-charts
-    version: 20.0.0
+    version: 19.7.2


### PR DESCRIPTION
Seems like prometheus chart rolled out a change with a bug which is causing the configmap reload container to fail with `unknown long flag '--volume-dir'`. Will wait for them to issue a fix, and rollback to the older version until then.