### PR TITLE
chore: bump dealer scrape job timeout

### DIFF
--- a/charts/monitoring/values.yaml
+++ b/charts/monitoring/values.yaml
@@ -91,7 +91,7 @@ prometheus:
         - job_name: 'dealer'
 
           scrape_interval: 1m
-          scrape_timeout: 20s
+          scrape_timeout: 45s
 
           kubernetes_sd_configs:
             - role: pod


### PR DESCRIPTION
The dealer scrape job is timing out and that's why there are no metrics being collected by prometheus