### PR TITLE
ci: add sleep to deps smoketest

### DIFF
--- a/ci/tasks/galoy-deps-smoketest.sh
+++ b/ci/tasks/galoy-deps-smoketest.sh
@@ -38,6 +38,9 @@ resource "kafka_topic" "smoketest_topic" {
 }
 EOF
 
+# Kafka cluster needs time to spin up
+sleep 10
+
 kubectl -n $kafka_namespace wait --for=condition=Ready pod -l strimzi.io/component-type=kafka
 
 terraform init


### PR DESCRIPTION
Attempt to fix failing smoketest where kubectl cannot find the resources that we're trying to wait upon