### PR TITLE
refactor: allow bitcoind host overriding in fulcrum

### DIFF
--- a/charts/fulcrum/templates/configmap.yaml
+++ b/charts/fulcrum/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     ws = 0.0.0.0:{{ .Values.service.ports.ws }}
     wss = 0.0.0.0:{{ .Values.service.ports.wss }}
     stats = 0.0.0.0:{{ .Values.service.ports.stats }}
-    bitcoind = bitcoind:{{ .Values.bitcoindRpcPort }}
+    bitcoind = {{ .Values.bitcoindRpcHost }}:{{ .Values.bitcoindRpcPort }}
     key = /.fulcrum/tls.key
     cert = /.fulcrum/tls.cert
   {{- if .Values.fulcrumGenericConfig }}

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -63,6 +63,7 @@ persistence:
 
 bitcoindRpcPassSecretName: bitcoind-rpcpassword
 bitcoindRpcPort: 8332
+bitcoindRpcHost: bitcoind
 
 fulcrumGenericConfig:
   # https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf


### PR DESCRIPTION
We need to be able to override this in testflight because bitcoind is in another namespace (staging).