### PR TITLE
chore: upgrade cronjob api version

### DIFF
--- a/charts/galoy/charts/price/templates/history-cronjob.yaml
+++ b/charts/galoy/charts/price/templates/history-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "price.fullname" . }}-history-cronjob

--- a/charts/galoy/templates/balance-notification-cronjob.yaml
+++ b/charts/galoy/templates/balance-notification-cronjob.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.galoy.balanceNotificationCron.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 
 metadata:

--- a/charts/galoy/templates/galoy-cronjob.yaml
+++ b/charts/galoy/templates/galoy-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 
 metadata:

--- a/charts/galoy/templates/mongo-backup-cronjob.yaml
+++ b/charts/galoy/templates/mongo-backup-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 
 metadata:


### PR DESCRIPTION
`batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob`
