### PR TITLE
feat: add static ip for bria api

### DIFF
--- a/charts/bria/templates/bria-api-svc.yaml
+++ b/charts/bria/templates/bria-api-svc.yaml
@@ -12,8 +12,8 @@ metadata:
   {{ end }}
 spec:
   type: {{ .Values.bria.api.service.type }}
-  {{ if and (eq .Values.bria.api.service.type "LoadBalancer") .Values.bria.api.service.staticIp }}
-  loadBalancerIP: {{ .Values.bria.api.service.staticIp }}
+  {{ if and (eq .Values.bria.api.service.type "LoadBalancer") .Values.bria.api.service.staticIP }}
+  loadBalancerIP: {{ .Values.bria.api.service.staticIP }}
   {{ end }}
   ports:
   - port: {{ .Values.bria.api.service.port }}

--- a/charts/bria/templates/bria-api-svc.yaml
+++ b/charts/bria/templates/bria-api-svc.yaml
@@ -6,8 +6,15 @@ metadata:
     app: {{ template "bria.fullname" . }}-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
+  {{ with .Values.bria.api.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 -}}
+  {{ end }}
 spec:
   type: {{ .Values.bria.api.service.type }}
+  {{ if and (eq .Values.bria.api.service.type "LoadBalancer") .Values.bria.api.service.staticIp }}
+  loadBalancerIP: {{ .Values.bria.api.service.staticIp }}
+  {{ end }}
   ports:
   - port: {{ .Values.bria.api.service.port }}
     targetPort: {{ .Values.bria.api.service.port }}

--- a/charts/bria/values.yaml
+++ b/charts/bria/values.yaml
@@ -23,7 +23,7 @@ bria:
       type: ClusterIP
       port: 2742
       staticIp: ""
-      annotations:
+      annotations: {}
 
   image:
     repository: us.gcr.io/galoy-org/bria

--- a/charts/bria/values.yaml
+++ b/charts/bria/values.yaml
@@ -22,6 +22,8 @@ bria:
     service:
       type: ClusterIP
       port: 2742
+      staticIp: ""
+      annotations:
 
   image:
     repository: us.gcr.io/galoy-org/bria

--- a/charts/bria/values.yaml
+++ b/charts/bria/values.yaml
@@ -22,7 +22,7 @@ bria:
     service:
       type: ClusterIP
       port: 2742
-      staticIp: ""
+      staticIP: ""
       annotations: {}
 
   image:


### PR DESCRIPTION
for GKE usage from bastion.

```yaml
  api:
    service:
      type: LoadBalancer
      staticIp: 10.1.2.1
      annotations:
         networking.gke.io/load-balancer-type: "Internal"
```