### PR TITLE
fix: 502 intermittent errors

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -15,6 +15,9 @@ metadata:
 
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "5s"
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
 
     nginx.ingress.kubernetes.io/limit-rpm: "60"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"

--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -15,7 +15,7 @@ metadata:
 
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "5s"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "1s"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout"
     nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
 


### PR DESCRIPTION
I think this should fix the 502 intermittent errors. I tested it in my local dev chart environment by force deleting the galoy api pod and running a curl on a loop (test script below). Before the nginx retry settings were applied I would get a lot of 502/503 errors when one pod was down and one pod was up. After the retry settings were applied I did not get any errors.

<img width="703" alt="Screen Shot 2023-04-17 at 6 30 29 PM" src="https://user-images.githubusercontent.com/1273575/232632373-038d3e52-196a-4bd7-94b2-f66e1e08d15f.png">

ping-502.sh 
```sh
#!/bin/bash
for i in {1..5000}
do
    response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4002/graphql)
    if [ $response -eq 502 ]
    then
        echo "502 error detected on request $i"
    else
        echo "Request $i successful, response code: $response"
    fi
    sleep 0.4
done
```