### PR TITLE
chore: decrease kratos livenessProbe periodSeconds

### DIFF
--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -846,8 +846,6 @@ kratos:
   replicaCount: 2
   deployment:
     livenessProbe:
-      failureThreshold: 5
-      initialDelaySeconds: 45
       periodSeconds: 1
   kratos:
     automigration:

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -844,6 +844,11 @@ kratos:
     public:
       enabled: false
   replicaCount: 2
+  deployment:
+    livenessProbe:
+      failureThreshold: 5
+      initialDelaySeconds: 45
+      periodSeconds: 1
   kratos:
     automigration:
       enabled: true


### PR DESCRIPTION
The defaults are:
```
`{"failureThreshold":5,"initialDelaySeconds":5,"periodSeconds":10}`
```
https://github.com/ory/k8s/blob/7f848abc734852ae2a26d1898ca9f4d1fc2ccc04/helm/charts/kratos/README.md?plain=1#L28