### PR TITLE
chore: limit the bitcoind load of fulcrum

### DIFF
--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -58,3 +58,5 @@ fulcrumGenericConfig:
   - peering = false
   - announce = false
   - fast-sync = 1024
+  - worker_threads = 1
+  - bitcoind_throttle = 25 10 2


### PR DESCRIPTION
Limiting the load fulcrum can exert on bitcoind with settings from:
https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf

```
# Work queue threads - 'worker_threads' - DEFAULT: 0 (= autodetect # of CPUs)
#
# The maximum number of worker threads that can simultaneously be spawned for
# work queue processing.

# BitcoinD request throttling - 'bitcoind_throttle - DEFAULT: 50 20 5
#
# This is an advanced parameter added to Fulcrum v1.0.4 to control and rate-
# limit client spamming of requests that hit bitcoind, e.g.
# 'blockchain.transaction.get'. The rationale for this facility is that it's
# possible for misbehaving clients to choke the system by hitting the server (in
# particular bitcoind) with many expensive, I/O-bound requests per unit time,
# which would degrade the responsiveness of the server to other clients.
#
# This parameter must be specified as a 3-tuple (whitespace or comma-delimited).
# The three items in the tuple are: "burst limit", "low water mark", and "decay
# per second" for the first, second, and third items, respectively. The
# definition of these three parameters is described below:
#
# "burst limit" - The number of simultaneous outstanding bitcoind-bound requests
# a client may send out at once. If a client has outstanding bitcoind-bound
# requests that have not yet returned results, and the number of such requests
# hits this limit, then the client will be throttled for at least 200
# milliseconds, or until the "low water mark" of extant request is reached
# (whichever is longer). In other words, the throttling is achieved by pausing
# all further processing of requests for that client, until either 200 ms
# has elapsed or the "low-water mark" for outstanding requests (default 20) is
# hit. The default value (50) for this burst parameter is a decent value that is
# neither too liberal nor too conservative.
#
# "low water mark" - If a client is paused, then the number of requests that are
# outstanding to bitcoind must dip below this number before it is unpaused.
#
# "decay per second" - If a client has outstanding requests, and bitcoind has
# not replied in some time, "credit" the client with this many requests towards
# their burst, per second.
#
# These parameters may be queried and/or adjusted dynamically at runtime via the
# FulcrumAdmin 'bitcoind_throttle' command.
#
#bitcoind_throttle = 50 20 5
```