### PR TITLE
fix: bitcoindCustomConfig parsing

### DIFF
--- a/charts/bitcoind/templates/configmap.yaml
+++ b/charts/bitcoind/templates/configmap.yaml
@@ -10,13 +10,13 @@ data:
     {{ . }}
   {{- end }}
   {{- range $k, $v := $.Values.bitcoindCustomConfig }}
-    {{ printf "%s=%s" $k $v}}
+    {{ printf "%s=%v" $k $v }}
   {{- end }}
   {{ .Values.global.network | indent 2 }}=1
   {{- $sections := splitList "," "test,regtest,signet" }}
   {{- range $sections }}
     {{printf "[%s]" . }}
     {{- range $k, $v := $.Values.bitcoindCustomConfig }}
-    {{ printf "%s=%s" $k $v}}
+    {{ printf "%s=%v" $k $v }}
     {{- end }}
   {{- end}}

--- a/dev/bitcoin/bitcoind-regtest-values.yml
+++ b/dev/bitcoin/bitcoind-regtest-values.yml
@@ -1,7 +1,7 @@
 global:
   network: regtest
   service:
-    ports: 
+    ports:
       rpc: 18443
 
 secrets:
@@ -21,4 +21,5 @@ bitcoindCustomConfig:
   bind: 0.0.0.0
   rpcbind: 0.0.0.0
   rpcallowip: 0.0.0.0/0
-  #fallbackfee: 0.0002
+  dbcache: 450
+  maxmempool: 300


### PR DESCRIPTION
chatGPT result on why:
`dbcache: 2600`
is converted to:
`dbcache=%!{float64=2600}`
with the current config?

>The error you're seeing is because you're trying to print a float64 type value with printf "%s=%s", which expects string arguments. The printf function in Go (and in this case, Go templating language which Helm uses) expects you to provide a format specifier that matches the type of the variable you're trying to print.

>The %s format specifier is used for strings. When you try to print a float64 using %s, it doesn't know how to convert it and hence the output dbcache=%!{float64=2600}.

>To fix this, you should use the %v format specifier, which is a generic format specifier that can print any type in its default format. 

Tested with the integer values quoted and unquoted as well - results in the good bitcoin.conf format now.