### PR TITLE
fix: remove sudo from Clean Up action

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -121,5 +121,5 @@ jobs:
       - name: Clean Up
         if: always()
         run: |
-          sudo rm -rf ci/tasks/smoketest-settings
+          rm -rf ci/tasks/smoketest-settings
           k3d cluster delete --all


### PR DESCRIPTION
Fixing the error:
```
Run sudo rm -rf ci/tasks/smoketest-settings
sudo: you do not exist in the passwd database
Error: Process completed with exit code 1.
```