### PR TITLE
build: add helm-dep-updates to Makefile

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -127,3 +127,7 @@ review:
 delete:
 	kubectl delete namespace $(ns) --force
 
+helm-dep-updates:
+	for dir in $$(ls ../charts); do \
+		cd ../charts/$$dir && helm dependency update && cd -; \
+	done


### PR DESCRIPTION
add the command in `./dev` :
```
make helm-dep-updates
```
to update all charts with dependencies.

The terraform `dependency_update  = true` is only meant for local cache and has no effect on the persisted helm chart files.