### PR TITLE
build: add concurrency to dev-smoketest action

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency: 
+  group: dev-smoketest-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   smoketest:
     name: Hit smoketests against Charts in Dev Setup


### PR DESCRIPTION
as configured concurrency cancels the previous workflow of a branch if a new commit is pushed

TODO: cancel the workflow when the PR is closed can use this third party action:
https://github.com/marketplace/actions/cancel-workflow-action
