### PR TITLE
build: add Cleanup after PR closed action

### DIFF
--- a/.github/workflows/cleanup-after-pr-closed.yaml
+++ b/.github/workflows/cleanup-after-pr-closed.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  cancel-runs:
+    name: 'Cleanup after PR closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cancel build runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          ignore_sha: true
+          workflow_id: dev-smoketest.yaml


### PR DESCRIPTION
Might need (as tested on my private repo):
```
          access_token: ${{ secrets.ACTIONS_TOKEN }}
```
A personal access token added to the secrets as `ACTIONS_TOKEN`
with permissions:
Actions (read and write)
Pull requests (read only)