### PR TITLE
revert: build: add concurrency to dev-smoketest action (#3534)

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -3,10 +3,6 @@ on:
   pull_request:
     branches: [main]
 
-concurrency: 
-  group: dev-smoketest-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   smoketest:
     name: Hit smoketests against Charts in Dev Setup


### PR DESCRIPTION
This reverts commit 4aa66d6f965faedd38b6e4d8907f5f2db79d7878.

The permission errors on the self hosted gh runner could be caused by one of the frequent job cancellations as a result of the concurrency setting.
Reverting to rule out as the source of the problem.
 
The self-hosted-gh-actions-runner would still likely need to be redeployed.