### PR TITLE
ci: always exit with 0 in dealer smoketest

### DIFF
--- a/ci/tasks/dealer-smoketest.sh
+++ b/ci/tasks/dealer-smoketest.sh
@@ -1,19 +1,3 @@
 #!/bin/bash
 
 set -eu
-
-source smoketest-settings/helpers.sh
-
-host=`setting "dealer_endpoint"`
-port=`setting "dealer_port"`
-
-set +e
-for i in {1..30}; do
-  echo "Attempt ${i} to curl dealer's /metrics endpoint"
-  curl --location -f ${host}:${port}/metrics
-  if [[ $? == 0 ]]; then success="true"; break; fi;
-  sleep 5
-done
-set -e
-
-if [[ "$success" != "true" ]]; then echo "Smoke test failed" && exit 1; fi;


### PR DESCRIPTION
Making the dealer smoketest a dummy since dealer is going to be deprecated soon