### PR TITLE
ci(dev): fix dev smoketest permission issue

### DIFF
--- a/ci/tasks/dev-smoketest-settings.sh
+++ b/ci/tasks/dev-smoketest-settings.sh
@@ -10,3 +10,5 @@ function setting_exists() {
   cat smoketest-settings/data.json | jq -r ".\$1 // null"
 }
 EOF
+
+chmod -R 777 smoketest-settings


### PR DESCRIPTION
The `dev-smoketest-settings.sh` script creates files as root and therefore the github actions, that run as a service account, do not have permissions to write over those files.
