### PR TITLE
ci: add sleep to kafka-connect smoketest

### DIFF
--- a/ci/tasks/kafka-connect-smoketest.sh
+++ b/ci/tasks/kafka-connect-smoketest.sh
@@ -16,7 +16,7 @@ if [ "${kafka_connect_api_host}" != "" ]; then
       success="true"
       break
     fi
-    sleep 1
+    sleep 3
   done
   set -e
 


### PR DESCRIPTION
To allow more time for the kafka-connect pod to be ready when it is deployed first.