### PR TITLE
chore: add FileConfigProvider, add secretMounts

### DIFF
--- a/charts/kafka-connect/templates/kafka-connect.yaml
+++ b/charts/kafka-connect/templates/kafka-connect.yaml
@@ -11,6 +11,8 @@ spec:
   bootstrapServers: "kafka-kafka-plain-bootstrap:9092"
   config:
     group.id: connect-cluster
+    config.providers: file
+    config.providers.file.class: org.apache.kafka.common.config.provider.FileConfigProvider
     offset.storage.topic: connect-cluster-offsets
     config.storage.topic: connect-cluster-configs
     status.storage.topic: connect-cluster-status
@@ -19,10 +21,12 @@ spec:
     status.storage.replication.factor: -1
   resources:
     {{ toYaml .Values.resources | nindent 6 }}
-{{- if .Values.secretName }}
+{{- if .Values.secretMounts }}
   externalConfiguration:
     volumes:
-      - name: kafka-sa-creds
+    {{- range .Values.secretMounts }}
+      - name: {{ . }}
         secret:
-          secretName: {{ .Values.secretName }}
+          secretName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/kafka-connect/values.yaml
+++ b/charts/kafka-connect/values.yaml
@@ -3,11 +3,15 @@ image:
   repository: us.gcr.io/galoy-org/kafka-connect
   digest: sha256:71addfbb20d5e5a7279256b44761a08604383490424be63d87c2f3b331831e65
   git_ref: 6a10312
+
 # Change to allow multiple kafka-connect instances
 kafkaConnectInstanceName: kafka
+
 ## The pods from this namespace are allowed to access the Kafka Connect API
 allowedNamespace: ""
-## The contents of secret can be used by the Kafka connectors running in the pod
-## Mounted to: /opt/kafka/external-configuration/<secretName>/<data.value>
-secretName: ""
+
+## The contents of the secrets are mounted as a file to be used by the Kafka connectors running in the pod
+## mounts to: /opt/kafka/external-configuration/<secretName>/<data.value>
+secretMounts: []
+
 resources: {}


### PR DESCRIPTION
Makes it possible to pass the mongo-connection-uri to the kafka-connect pod as a file from a secret.