### PR TITLE
ci: fix galoy testflight twilio creds

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -97,7 +97,7 @@ resource "kubernetes_secret" "twilio_secret" {
 
   data = {
     TWILIO_VERIFY_SERVICE_ID = ""
-    TWILIO_ACCOUNT_SID       = ""
+    TWILIO_ACCOUNT_SID       = "AC"
     TWILIO_AUTH_TOKEN        = ""
   }
 }


### PR DESCRIPTION
The twilio sdk doesn't like an empty account sid anymore
