### PR TITLE
fix: apollo router config for web apps

### DIFF
--- a/charts/galoy/apollo-router/main.rhai
+++ b/charts/galoy/apollo-router/main.rhai
@@ -1,0 +1,23 @@
+fn supergraph_service(service) {
+  let add_cookies_to_response = |response| {
+    if response.context["set_cookie_headers"]?.len > 0 {
+      response.headers["set-cookie"] = response.context["set_cookie_headers"];
+    }
+  };
+
+  service.map_response(add_cookies_to_response);
+}
+
+fn subgraph_service(service, subgraph) {
+  let store_cookies_from_subgraphs = |response| {
+    if "set-cookie" in response.headers {
+      if response.context["set_cookie_headers"] == () {
+        response.context.set_cookie_headers = []
+      }
+
+      response.context.set_cookie_headers += response.headers.values("set-cookie");
+    }
+  };
+
+  service.map_response(store_cookies_from_subgraphs);
+}

--- a/charts/galoy/templates/router-supergraph-cm.yaml
+++ b/charts/galoy/templates/router-supergraph-cm.yaml
@@ -9,3 +9,5 @@ metadata:
 data:
   supergraph-schema.graphql: |-
 {{ .Files.Get .Values.router.supergraphFilePath | indent 4 }}
+  main.rhai: |-
+{{ .Files.Get .Values.router.rhaiScriptFilePath | indent 4 }}

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -1181,7 +1181,7 @@ router:
         name: galoy-supergraph
     - name: rhai
       configMap:
-        name: galoy-rhai
+        name: galoy-supergraph
   router:
     configuration:
       include_subgraph_errors:

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -1205,15 +1205,6 @@ router:
           otlp:
             endpoint: http://localhost:4318
             protocol: http
-        experimental_logging: # TODO REMOVE just for local charts env debugging
-          format: json
-          display_filename: true
-          display_line_number: false
-      cors:
-        match_origins:
-          - "^http://([a-z0-9]+[.])*" # http
-          - "^https://([a-z0-9]+[.])*" # https
-        allow_credentials: true # for cookie auth
       rhai:
         scripts: "/etc/apollo"
         main: "main.rhai"

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -1162,6 +1162,7 @@ kratos:
     emailTemplates: {}
 router:
   supergraphFilePath: apollo-router/supergraph.graphql
+  rhaiScriptFilePath: apollo-router/main.rhai
   extraEnvVars:
     - name: APOLLO_ROUTER_SUPERGRAPH_PATH
       value: /etc/apollo/supergraph-schema.graphql
@@ -1171,10 +1172,16 @@ router:
     - name: supergraph
       mountPath: /etc/apollo/supergraph-schema.graphql
       subPath: supergraph-schema.graphql
+    - name: rhai
+      mountPath: /etc/apollo/main.rhai
+      subPath: main.rhai
   extraVolumes:
     - name: supergraph
       configMap:
         name: galoy-supergraph
+    - name: rhai
+      configMap:
+        name: galoy-rhai
   router:
     configuration:
       include_subgraph_errors:
@@ -1198,3 +1205,15 @@ router:
           otlp:
             endpoint: http://localhost:4318
             protocol: http
+        experimental_logging: # TODO REMOVE just for local charts env debugging
+          format: json
+          display_filename: true
+          display_line_number: false
+      cors:
+        match_origins:
+          - "^http://([a-z0-9]+[.])*" # http
+          - "^https://([a-z0-9]+[.])*" # https
+        allow_credentials: true # for cookie auth
+      rhai:
+        scripts: "/etc/apollo"
+        main: "main.rhai"

--- a/dev/README.md
+++ b/dev/README.md
@@ -30,7 +30,7 @@ Currently successfully brings up charts - no guarantee that everything is workin
 
 1. get session token
     ```
-    curl -ksS 'https://localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+59981730222","code":"111111"}}}' | jq '.data.userLogin.authToken'
+    curl -ksS 'https://localhost:8080/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+16505554321","code":"321321"}}}' | jq '.data.userLogin.authToken'
     ```
 
     Example result:
@@ -143,8 +143,8 @@ Currently successfully brings up charts - no guarantee that everything is workin
   ```
   host=localhost
   port=4455
-  phone='+59981730222'
-  code='111111'
+  phone='+16505554321'
+  code='321321'
 
   # apollo-playground-ui
   curl -LksSf "${host}:${port}/graphql" \

--- a/dev/galoy/galoy-values.yml.tmpl
+++ b/dev/galoy/galoy-values.yml.tmpl
@@ -54,3 +54,16 @@ kratos:
                           value: ${kratos_callback_api_key}
                           in: header
                   - hook: session
+router:
+  router:
+    configuration:
+      telemetry:
+        experimental_logging:
+          format: json
+          display_filename: true
+          display_line_number: false
+      cors:
+        match_origins:
+          - "^http://([a-z0-9]+[.])*"
+          - "^https://([a-z0-9]+[.])*"
+        allow_credentials: true

--- a/dev/galoy/main.tf
+++ b/dev/galoy/main.tf
@@ -15,8 +15,8 @@ locals {
   galoy-oathkeeper-proxy-host = "galoy-oathkeeper-proxy.${local.galoy_namespace}.svc.cluster.local"
   kratos_pg_host              = "postgresql.${local.galoy_namespace}.svc.cluster.local"
 
-  bankowner_phone = "+59981730222"
-  bankowner_code  = "111111"
+  bankowner_phone = "+16505554321"
+  bankowner_code  = "321321"
 }
 
 resource "kubernetes_namespace" "galoy" {


### PR DESCRIPTION
This PR adds a `rhai` script to fix cookie propagation auth issues in Web Wallet. The scripts makes sure the cookie response headers are passed back thru the apollo router (only request header propagate via yaml, so a rhai script is needed for the response headers). docs here: https://www.apollographql.com/docs/router/configuration/header-propagation/#response-header-propagation