### PR TITLE
chore: making the session token valid for longer

### DIFF
--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -18,7 +18,6 @@ galoy:
   router:
     port: 80
   config:
-
     bria:
       hotWalletName: dev
       queueNames:
@@ -752,7 +751,7 @@ oathkeeper:
                 "preserve_path": true,
                 "preserve_query": true,
                 "subject_from": "identity.id",
-                "extra_from": "identity.traits"
+                "extra_from": "@this"
               }
             },
             {
@@ -762,7 +761,7 @@ oathkeeper:
                 "preserve_path": true,
                 "preserve_query": true,
                 "subject_from": "identity.id",
-                "extra_from": "identity.traits"
+                "extra_from": "@this"
               }
             },
             { "handler": "anonymous" }
@@ -771,8 +770,8 @@ oathkeeper:
           "mutators": [
             {
               "handler": "id_token",
-              "config": {
-                "claims": "{\"sub\": \"{{ print .Subject }}\"}"
+              "config": { 
+                "claims": '{"sub": "{{ print .Subject }}", "session_id": "{{ print .Extra.id }}", "expires_at": "{{ print .Extra.expires_at }}" }'
               }
             }
           ]
@@ -795,7 +794,7 @@ oathkeeper:
                 "preserve_path": true,
                 "preserve_query": true,
                 "subject_from": "identity.id",
-                "extra_from": "identity.traits"
+                "extra_from": "@this"
               }
             },
             {
@@ -805,7 +804,7 @@ oathkeeper:
                 "preserve_path": true,
                 "preserve_query": true,
                 "subject_from": "identity.id",
-                "extra_from": "identity.traits"
+                "extra_from": "@this"
               }
             },
             { "handler": "anonymous" }
@@ -816,7 +815,9 @@ oathkeeper:
           "mutators": [
             {
               "handler": "id_token",
-              "config": { "claims": '{"sub": "{{ print .Subject }}"}' }
+              "config": { 
+                "claims": '{"sub": "{{ print .Subject }}"}' 
+              }
             }
           ]
         }

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -977,7 +977,7 @@ kratos:
             url: file:///etc/config/phone_email_no_password_v0.identity.schema.json
         default_schema_id: phone_no_password_v0
       session:
-        lifespan: "720h" # 1 month
+        lifespan: "9360h" # 1 year and 1 month
         earliest_possible_extend: "96h" # 4 days
         whoami:
           required_aal: highest_available

--- a/dev/README.md
+++ b/dev/README.md
@@ -50,7 +50,7 @@ Currently successfully brings up charts - no guarantee that everything is workin
 
 1. get session token
     ```
-    curl -ksS 'http://localhost:4002/admin/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+16505554321","code":"321321"}}}' | jq '.data.userLogin.authToken'
+    curl -ksS 'http://localhost:4002/admin/graphql' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-binary '{"query":"mutation login($input: UserLoginInput!) { userLogin(input: $input) { authToken } }","variables":{"input":{"phone":"+16505554321","code":"000000"}}}' | jq '.data.userLogin.authToken'
     ```
 
     Example result:


### PR DESCRIPTION
I want the token to refresh when it's been used, instead of doing it from the cronjob. 2 reasons:
- having the refresh in the cronjob had lead to multiple incident in the past, where the cronjob was failing in multiple ways
- if a device is not been used, in the current design, the token would still be valid even years later. with a "refresh only when the token is used", token that are no longer used would, after some time, be invalid. user would need to log back in

for this new mode of operation to work, we need to make the token valid for longer. I'm suggesting 13 months, and the token expiration would be automatically renew when its validity is less than 12 months.