### PR TITLE
refactor: remove common chart dep from bria

### DIFF
--- a/charts/bria/Chart.lock
+++ b/charts/bria/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.6
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 2.10.1
-digest: sha256:5f8133055fd43421996e76c7e8a31420434f3c8ffede3af40efd9a80b674c199
-generated: "2023-09-08T11:32:57.328881944Z"
+digest: sha256:e9f252a13edc2a9ecde83ea222591e1767aa08f97fb7c9071d69c49bff78a481
+generated: "2023-09-17T21:35:05.480571218+05:30"

--- a/charts/bria/Chart.yaml
+++ b/charts/bria/Chart.yaml
@@ -24,6 +24,3 @@ dependencies:
     version: 11.9.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    version: 2.10.1


### PR DESCRIPTION
It's not being used anywhere in the bria chart.