### PR TITLE
chore: bump api ingress rate limits

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -15,9 +15,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "1s"
     nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout"
     nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
-    nginx.ingress.kubernetes.io/limit-rpm: "60"
-    nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"
-    nginx.ingress.kubernetes.io/limit-connections: "80"
+    nginx.ingress.kubernetes.io/limit-rpm: "120"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "80"
+    nginx.ingress.kubernetes.io/limit-connections: "160"
     nginx.ingress.kubernetes.io/auth-url: "http://galoy-oathkeeper-api.{{ .Release.Namespace }}.svc.cluster.local:4456/decisions"
     nginx.ingress.kubernetes.io/auth-method: GET
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, Set-Cookie"


### PR DESCRIPTION
@nicolasburtey Not sure if the burst multiplier should be left as is