### PR TITLE
chore: make hydra dependency optional

### DIFF
--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -37,6 +37,7 @@ dependencies:
   - name: hydra
     repository: https://k8s.ory.sh/helm/charts
     version: 0.36.0
+    condition: hydra.enabled
   - name: router
     repository: oci://ghcr.io/apollographql/helm-charts
     version: 1.25.0

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -1158,6 +1158,7 @@ kratos:
         }
     emailTemplates: {}
 hydra:
+  enabled: true
   maester:
     enabled: false
   hydra:


### PR DESCRIPTION
Dear Galoy team,

In my infra I am already running the hydra stack in its own namespace. I think making it an optional dependency allows for greater flexibility downstream.

Thank you,
Zoop