### PR TITLE
chore: add app labels to cronjobs jobTemplate

### DIFF
--- a/charts/galoy/charts/price/templates/history-cronjob.yaml
+++ b/charts/galoy/charts/price/templates/history-cronjob.yaml
@@ -10,6 +10,9 @@ spec:
     spec:
       activeDeadlineSeconds: 60
       template:
+        metadata:
+          labels:
+            app: {{ include "price.history.fullname" . }}-cronjob
         spec:
           containers:
           - name: update-price

--- a/charts/galoy/templates/galoy-cronjob.yaml
+++ b/charts/galoy/templates/galoy-cronjob.yaml
@@ -19,6 +19,7 @@ spec:
       template:
         metadata:
           labels:
+            app: {{ template "galoy.cron.jobname" . }}
         spec:
           serviceAccountName: {{ template "galoy.name" . }}
           restartPolicy: OnFailure

--- a/charts/galoy/templates/mongo-backup-cronjob.yaml
+++ b/charts/galoy/templates/mongo-backup-cronjob.yaml
@@ -17,6 +17,9 @@ spec:
       activeDeadlineSeconds: 300
 
       template:
+        metadata:
+          labels:
+            app: {{ template "galoy.mongoBackupCron.jobname" . }}
         spec:
           restartPolicy: OnFailure
 


### PR DESCRIPTION
This will add the "app" label to the pods created by the cronjobs.
This way it's easier to target them for network policies and make them more visible in observational tools.