### PR TITLE
chore: replace helm revision with timestamp in migration jobnames

### DIFF
--- a/charts/galoy/charts/price/templates/history-migration-job.yaml
+++ b/charts/galoy/charts/price/templates/history-migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "price.history.fullname" . }}-postgres-migrate-{{ .Release.Revision }}
+  name: {{ include "price.history.fullname" . }}-postgres-migrate-{{ now | unixEpoch }}
 spec:
   backoffLimit: 3
   template:

--- a/charts/galoy/templates/_helpers.tpl
+++ b/charts/galoy/templates/_helpers.tpl
@@ -1,4 +1,12 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a timestamp of the current helm release time.
+*/}}
+{{- define "releasetime" -}}
+{{- now | unixEpoch -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -71,14 +79,14 @@ Mongo Backup CronJob name
 Migration Job name
 */}}
 {{- define "galoy.migration.jobname" -}}
-{{- printf "%s-mongodb-migrate-%d" .Release.Name .Release.Revision -}}
+{{- printf "%s-mongodb-migrate-" .Release.Name -}}{{- template "releasetime" -}}
 {{- end -}}
 
 {{/*
 Pre-Migration Job name
 */}}
 {{- define "galoy.preMigration.jobname" -}}
-{{- printf "%s-pre-mongodb-migrate-%d" .Release.Name .Release.Revision -}}
+{{- printf "%s-pre-mongodb-migrate-" .Release.Name -}}{{- template "releasetime" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This pull request will make it possible to use the galoy helm chart in CD pipelines and tools like argoCD which use `helm template` before applying the manifests to kubernetes.

Since the helm template command doesn't update the revision number they'd get errors due to trying to overwrite existing migration jobs.

As workaround I recommend to name them via a timestamp instead of a revision. In this example I use a unix timestamp but we could also use a prettier formatting like:
```
{{- now | date "20060102150405" -}}
```