### PR TITLE
chore: unsecure login code in galoy chart

### DIFF
--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -124,6 +124,14 @@ spec:
         - name: MATTERMOST_WEBHOOK_URL
           value: {{ .Values.galoy.mattermostWebhookUrl | quote }}
 
+        {{ if .Values.galoy.api.unsecureDefaultLoginCode.enabled }}
+        - name: UNSECURE_DEFAULT_LOGIN_CODE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.api.unsecureDefaultLoginCode.existingSecret.name }}
+              key: {{ .Values.galoy.api.unsecureDefaultLoginCode.existingSecret.key }}
+        {{ end }}
+
         {{ if .Values.galoy.api.firebaseNotifications.enabled }}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/tmp/firebase-service-account/service-account.json"

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -117,6 +117,13 @@ galoy:
         name: galoyapp-firebase-serviceaccount
         # Secret Key
         key: galoyapp-firebase-serviceaccount.json
+    ## CAUTION - UNSECURE FLAG!
+    ## Enable Unsercure default logins to any phone number via the code
+    unsecureDefaultLoginCode:
+      enabled: false # Should be disabled in all production systems
+      existingSecret:
+        name: galoyapp-unsecure-login-code
+        key: code
     ## Liveness/Readiness Probes Configuration
     ## Determines if pod is healthy or if it should be killed.
     ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/


### PR DESCRIPTION
Adds capability to set an environment variable that lets any phone number login. This is an insecure flag. It's disabled by default.