### PR TITLE
chore: update fulcrum to v1.9.2

### DIFF
--- a/charts/fulcrum/Chart.yaml
+++ b/charts/fulcrum/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3-dev
+version: 0.3.4-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.9.1
+appVersion: 1.9.2

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -4,7 +4,7 @@ secrets:
 image:
   repository: cculianu/fulcrum
   pullPolicy: IfNotPresent
-  tag: v1.9.1
+  tag: v1.9.2
 
 # If true, generate blocks to the bitcoind node. Will fail if bitcoind is not in regtest mode.
 # The bitcoind installation should be in the same namespace as the fulcrum installation.


### PR DESCRIPTION
The Dockerhub release is manually triggered for now: https://github.com/cculianu/Fulcrum/issues/143