### PR TITLE
ci(dev): ignore notifications pod readiness

### DIFF
--- a/dev/galoy/Tiltfile
+++ b/dev/galoy/Tiltfile
@@ -207,6 +207,7 @@ k8s_resource(workload='galoy-price-history-postgres-migrate-1', pod_readiness='i
 k8s_resource(workload='galoy-mongo-backup', pod_readiness='ignore')
 
 k8s_resource(workload='api-keys', pod_readiness='ignore')
+k8s_resource(workload='notifications', pod_readiness='ignore')
 
 k8s_yaml(secret_from_dict(
   name='galoy-smoketest',


### PR DESCRIPTION
Adding notifications pod to the list of pods we ignore in tilt ci as it hasn't been setup in the dev workflow yet.