### PR TITLE
chore: filter out query planning spans from router

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -116,6 +116,7 @@ opentelemetry-collector:
         traces:
           span:
             - 'kind.string != "Server" and IsMatch(resource.attributes["service.name"], ".*-kratos")'
+            - 'name == "query_planning" and IsMatch(resource.attributes["service.name"], ".*-router")'
           spanevent:
             - 'name == "" and IsMatch(resource.attributes["service.name"], ".*-router")'
     receivers:


### PR DESCRIPTION
We have about 180k events for this per day