### PR TITLE
chore: update bitcoind to v27.0

### DIFF
--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -129,7 +129,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if and .Values.descriptor.secretName .Values.descriptor.secretKey }}
         - name: descriptor-import
-          image: lncm/bitcoind:v25.1
+          image: lncm/bitcoind:v27.0
           command: ['/bin/sh']
           args:
           - '-c'

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   repository: lncm/bitcoind
   pullPolicy: IfNotPresent
-  tag: v25.1
+  tag: v27.0
 
 extraInitContainers: []
 sidecarContainers: []

--- a/images/chain-dl/Dockerfile
+++ b/images/chain-dl/Dockerfile
@@ -1,4 +1,4 @@
-FROM lncm/bitcoind:v25.1
+FROM lncm/bitcoind:v27.0
 
 USER root
 


### PR DESCRIPTION
Merge before or after deploy https://github.com/GaloyMoney/charts/pull/6678 to prod