### PR TITLE
chore(galoy-api): enable cors

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "1s"


### PR DESCRIPTION
I used this PR https://github.com/GaloyMoney/charts/pull/2487 as a base.

I think the default values are enough but maybe it would be better to do another review https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#enable-cors