### PR TITLE
fix: api ingress cors allow header oauth2-token

### DIFF
--- a/charts/galoy/templates/api-ingress.yaml
+++ b/charts/galoy/templates/api-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-API-KEY"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-API-KEY,oauth2-token"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "1s"


### PR DESCRIPTION
allowing the header oauth2-token to fix the invoice generation error when logged in to the PoS