### PR TITLE
fix: otel upgrade

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -20,6 +20,8 @@ kubemonkey:
   resources: {}
 
 opentelemetry-collector:
+  image:
+    repository: "otel/opentelemetry-collector-k8s"
   service:
     enabled: true
   extraEnvs:


### PR DESCRIPTION
Need to explicitly define the image we want to use now. Previously otel was using the contrib image but there's a newer k8s specific image they recommend - https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890