### PR TITLE
chore: remove deprecated lnd config field

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -66,7 +66,6 @@ lndGeneralConfig:
   - rpclisten=0.0.0.0:10009
   - listen=0.0.0.0:9735
   - prometheus.listen=0.0.0.0:9092
-  - bitcoin.active=true
   - bitcoin.node=bitcoind
   - bitcoind.rpcuser=rpcuser
   - bitcoind.zmqpubrawblock=tcp://bitcoind:28332


### PR DESCRIPTION
bitcoin.active is depreacated now as its the only chain supported - https://docs.lightning.engineering/lightning-network-tools/lnd/lnd.conf
