### PR TITLE
fix(otel): Explicitly specify memory_limiter value

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -118,8 +118,14 @@ opentelemetry-collector:
         - key: graphql.variables.input.authToken
           action: update
           value: "<redacted>"
-      # If set to null, will be overridden with values based on k8s resource limits
-      memory_limiter: null
+      # Default memory limiter configuration for the collector based on k8s resource limits.
+      memory_limiter:
+        # check_interval is the time between measurements of memory usage.
+        check_interval: 5s
+        # By default limit_mib is set to 80% of ".Values.resources.limits.memory"
+        limit_percentage: 80
+        # By default spike_limit_mib is set to 25% of ".Values.resources.limits.memory"
+        spike_limit_percentage: 25
       resourcedetection:
         detectors: [env, gcp]
         timeout: 5s


### PR DESCRIPTION
This PR addresses the error "references processor 'memory_limiter' which is not configured". The issue arose from a change in how null values are interpreted for the memory_limiter property. Previously, setting it to null would use the default value. However, there was an inconsistency where some queries would disable the memory limiter when set to null, while others would use the default value.

To resolve this, the PR explicitly specifies the default value for the `memory_limiter` property. This approach ensures consistent behavior across all queries and serves as a potential fix for the error.

Reference: 
https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1272
https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1275