### PR TITLE
ci: match tilt test k3s version with dev and prod

### DIFF
--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -16,6 +16,7 @@ jobs:
       name: "Create Single Cluster"
       with:
         cluster-name: "k3s-default"
+        k3d-version: v5.7.4
         args: >-
           --image rancher/k3s:v1.30.4-k3s1
           -v "$(pwd):/charts"

--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         cluster-name: "k3s-default"
         args: >-
-          --image rancher/k3s:v1.27.4-k3s1
+          --image rancher/k3s:v1.30.4-k3s1
           -v "$(pwd):/charts"
           --k3s-arg --disable=traefik@server:0
           --k3s-arg --disable=servicelb@server:0


### PR DESCRIPTION
matching the k3s version used in dev since https://github.com/GaloyMoney/charts/pull/7091