### PR TITLE
fix: do not verify kubeletstats endpoint cert

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -148,6 +148,7 @@ opentelemetry-collector:
         collection_interval: 60s
         auth_type: "serviceAccount"
         endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
       jaeger:
         protocols:
           grpc:


### PR DESCRIPTION
Fixing the error leading to not receiving memory and cpu usage metrics.

The kubestats endpoint has a self-signed certificate which fails the verification by the otel pod.

The solution is recommended here: https://github.com/kubernetes/kubernetes/issues/125956

Related docs:
https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md