### PR TITLE
chore(deps): Update postgresql helm chart in Bria

### DIFF
--- a/charts/bria/Chart.lock
+++ b/charts/bria/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.6
-digest: sha256:e9f252a13edc2a9ecde83ea222591e1767aa08f97fb7c9071d69c49bff78a481
-generated: "2023-09-17T21:35:05.480571218+05:30"
+  version: 14.0.1
+digest: sha256:d85b78232b9cbaef3bba6d971c8af4ec26e013941fadfcb177eec1bb8e46e718
+generated: "2024-10-08T14:14:03.297141114+05:30"

--- a/charts/bria/Chart.yaml
+++ b/charts/bria/Chart.yaml
@@ -21,6 +21,6 @@ version: 0.10.16-dev
 appVersion: 0.1.107
 dependencies:
   - name: postgresql
-    version: 11.9.6
+    version: 14.0.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
This PR updates Postgres Helm Chart Dependencies PG11 -> PG14.