### PR TITLE
chore(deps): Update postgresql helm chart in Galoy and Voucher

### DIFF
--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 15.6.26
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 14.1.0
+  version: 15.1.0
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
   version: 0.39.1
@@ -20,5 +20,5 @@ dependencies:
 - name: router
   repository: oci://ghcr.io/apollographql/helm-charts
   version: 1.25.0
-digest: sha256:071175ef94695c4477503e17dfe7c49b448dfce97261b1519ed5562432710208
-generated: "2024-10-08T14:32:40.293975056+05:30"
+digest: sha256:4e46260055939492b22dc6d06f5c96b6395a96961d66030e6efa4896959a8a86
+generated: "2024-10-08T14:52:27.463269953+05:30"

--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 15.6.26
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.13
+  version: 14.1.0
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts
   version: 0.39.1
@@ -20,5 +20,5 @@ dependencies:
 - name: router
   repository: oci://ghcr.io/apollographql/helm-charts
   version: 1.25.0
-digest: sha256:60b19442cd85b259ac37748be97c92b461710c9c4ae7741e7bfecdeebdf9a576
-generated: "2024-10-02T22:24:17.573380002Z"
+digest: sha256:071175ef94695c4477503e17dfe7c49b448dfce97261b1519ed5562432710208
+generated: "2024-10-08T14:32:40.293975056+05:30"

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 15.6.26
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 11.9.13
+    version: 14.1.0
     condition: postgresql.enabled
   - name: oathkeeper
     repository: https://k8s.ory.sh/helm/charts

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     version: 15.6.26
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 14.1.0
+    version: 15.1.0
     condition: postgresql.enabled
   - name: oathkeeper
     repository: https://k8s.ory.sh/helm/charts

--- a/charts/voucher/Chart.lock
+++ b/charts/voucher/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.6
-digest: sha256:e9f252a13edc2a9ecde83ea222591e1767aa08f97fb7c9071d69c49bff78a481
-generated: "2024-05-22T17:49:55.172043+05:30"
+  version: 15.1.0
+digest: sha256:ad382e4b364c5b546451c2641748f8e7dbf93ac4a0a2858597180045d83fbcba
+generated: "2024-10-08T14:50:10.663588624+05:30"

--- a/charts/voucher/Chart.yaml
+++ b/charts/voucher/Chart.yaml
@@ -20,6 +20,6 @@ version: 0.1.0-dev
 appVersion: 0.1.0
 dependencies:
   - name: postgresql
-    version: 11.9.6
+    version: 15.1.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
This PR updates Postgres Helm Chart Dependencies PG11 -> PG14 for voucher and galoy in blink monorepo.