### PR TITLE
chore: update fulcrum and adapt config to large wallets

### DIFF
--- a/charts/fulcrum/Chart.yaml
+++ b/charts/fulcrum/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.17-dev
+version: 0.5.18-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.9.7
+appVersion: 1.11.1

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -4,7 +4,7 @@ secrets:
 image:
   repository: cculianu/fulcrum
   pullPolicy: IfNotPresent
-  tag: v1.9.7
+  tag: v1.11.1
 
 # If true, generate blocks to the bitcoind node. Will fail if bitcoind is not in regtest mode.
 # The bitcoind installation should be in the same namespace as the fulcrum installation.
@@ -57,6 +57,7 @@ fulcrumGenericConfig:
   - bitcoind_clients = 1
   - peering = false
   - announce = false
-  - fast-sync = 1024
+  - utxo_cache = 1024
   - worker_threads = 1
   - bitcoind_throttle = 25 10 2
+  - max_subs_per_ip = 1000000


### PR DESCRIPTION
Config details from: https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf

`max_subs_per_ip = 1000000` does allow to sync wallets tracking more than the default 75000 addresses.

The global `max_subs` limit  (DEFAULT: 10M) still applies.

```
# Maximum subscriptions (global limit) - 'max_subs' - DEFAULT: 10000000
#
# The maximum number of simultaneous script hash subscription that the server
# supports. If more than this number of subscriptions is requested by clients
# (unlikely) then the server will refuse new subscription requests. It will then
# kick off a background task to find the most-subscribed IP address and kick all
# the clients coming from that IP, and then clean up the subscription table.
#
# This config parameter was added in Fulcrum 1.0.5 as a measure to prevent
# clients from potentially exhausting server resources.
#
#max_subs = 10000000


# Maximum subscriptions (per-IP address) - 'max_subs_per_ip' - DEFAULT: 75000
#
# The maximum number of script hash subscriptions per IP address. Note that IP
# addresses matching 'subnets_to_exclude_from_per_ip_limits' will not be
# subjected to this limit (they will still be subjected to the global 'max_subs'
# limit, however).
#
# If a client attempts to subscribe beyond this limit for all the connections
# coming from their IP address, it will receive an error message.
#
#max_subs_per_ip = 75000
```

`utxo_cache` was called `fast-sync` previously.
It only affects the initial sync of fulcrum:
```
#-------------------------------------------------------------------------------
# OPTIONS USED ONLY DURING INITIAL SYNC
#-------------------------------------------------------------------------------

# UTXO cache = 'utxo_cache' - DEFAULT: 0
#
# If specified, Fulcrum will use a UTXO Cache that consumes extra memory but
# syncs up to to 2X faster. To use this feature, you must specify a memory value
# in MB to allocate to the cache. It is recommended that you give this facility
# at least 500 MB for it to really pay off, although any amount of memory given
# (minimum 64 MB) should be beneficial. Note that this feature is currently
# experimental and the tradeoffs are: it is faster because it avoids redundant
# disk I/O, however, this comes at the price of considerable memory consumption
# as well as a sync that is less resilient to crashes mid-sync. If the process
# is killed mid-sync, the database may become corrupt and lose UTXO data. Use
# this feature only if you are 100% sure that won't happen during a sync.
# The default is off (0). This option only takes effect on initial sync,
# otherwise this option has no effect.
#
#utxo_cache = 0
```
