### PR TITLE
chore: update fulcrum chart to enable admin and longer termination grace period

### DIFF
--- a/charts/fulcrum/templates/configmap.yaml
+++ b/charts/fulcrum/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
     ws = 0.0.0.0:{{ .Values.service.ports.ws }}
     wss = 0.0.0.0:{{ .Values.service.ports.wss }}
     stats = 0.0.0.0:{{ .Values.service.ports.stats }}
+    admin = 0.0.0.0:{{ .Values.service.ports.admin }}
     bitcoind = {{ .Values.bitcoindRpcHost }}:{{ .Values.bitcoindRpcPort }}
     key = /.fulcrum/tls.key
     cert = /.fulcrum/tls.cert

--- a/charts/fulcrum/templates/statefulset.yaml
+++ b/charts/fulcrum/templates/statefulset.yaml
@@ -95,8 +95,8 @@ spec:
           livenessProbe:
             tcpSocket:
               port: ssl
-            # allow 10h for initial sync
-            initialDelaySeconds: 36000
+            # allow up to ~4 days for initial sync
+            initialDelaySeconds: 360000
             periodSeconds: 10
             failureThreshold: 2
           # Define the resources to be created

--- a/charts/fulcrum/values.yaml
+++ b/charts/fulcrum/values.yaml
@@ -30,6 +30,7 @@ service:
     ws: 50003
     wss: 50004
     stats: 8080
+    admin: 8000
 
 ingress:
   enabled: false
@@ -40,6 +41,8 @@ ingress:
   tls: []
 
 resources: {}
+
+terminationGracePeriodSeconds: 600
 
 persistence:
   enabled: true


### PR DESCRIPTION
- Enable admin to allow manual stops
- Update initialDelaySeconds in livenessProbe to allow initial sync with current network conditions
- Add terminationGracePeriodSeconds to use 10 mins (similar to lnd) to avoid db corruption