### PR TITLE
revert: chore(deps): update postgresql helm chart in bria

### DIFF
--- a/charts/bria/Chart.lock
+++ b/charts/bria/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.16
-digest: sha256:1a3e7832059cadd377d6632c1797bf9978894a355a559500ddda3f8b8bbec2c9
-generated: "2025-03-04T01:52:04.739489987Z"
+  version: 14.0.1
+digest: sha256:d85b78232b9cbaef3bba6d971c8af4ec26e013941fadfcb177eec1bb8e46e718
+generated: "2024-10-08T14:14:03.297141114+05:30"

--- a/charts/bria/Chart.yaml
+++ b/charts/bria/Chart.yaml
@@ -21,6 +21,6 @@ version: 0.10.17-dev
 appVersion: 0.1.111
 dependencies:
   - name: postgresql
-    version: 16.4.16
+    version: 14.0.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled


### PR DESCRIPTION
Reverts GaloyMoney/charts#7531

Failing testflight with a postgres related error:

```
k -n bria-testflight-a1b4894 logs  bria-6f97456c99-qswcg
Defaulted container "bria" out of: bria, wait-for-postgresql (init)
Sending traces to http://localhost:4317
Starting server processes
Error: while executing migration 20210316025847: error returned from database: function uuid_nil() does not exist

Caused by:
    0: error returned from database: function uuid_nil() does not exist
    1: function uuid_nil() does not exist
 ```