### PR TITLE
chore: make galoy-nostr image configurable in galoy-pay chart

### DIFF
--- a/charts/galoy-pay/values.yaml
+++ b/charts/galoy-pay/values.yaml
@@ -22,8 +22,9 @@ secrets:
 galoy-nostr:
   enabled: true
   fullnameOverride: galoy-nostr
-  repository: krtk6160/galoy-nostr
-  digest: "sha256:cc82a694f81870c0becdc1b243ea9d4fca8b4ce497e70f4733d7b0539b462f19"
+  image:
+    repository: krtk6160/galoy-nostr
+    digest: "sha256:cc82a694f81870c0becdc1b243ea9d4fca8b4ce497e70f4733d7b0539b462f19"
 redis:
   redis0Dns: "galoy-redis-node-0.galoy-redis-headless"
   redis1Dns: "galoy-redis-node-1.galoy-redis-headless"

--- a/charts/galoy-pay/values.yaml
+++ b/charts/galoy-pay/values.yaml
@@ -22,6 +22,8 @@ secrets:
 galoy-nostr:
   enabled: true
   fullnameOverride: galoy-nostr
+  repository: krtk6160/galoy-nostr
+  digest: "sha256:cc82a694f81870c0becdc1b243ea9d4fca8b4ce497e70f4733d7b0539b462f19"
 redis:
   redis0Dns: "galoy-redis-node-0.galoy-redis-headless"
   redis1Dns: "galoy-redis-node-1.galoy-redis-headless"


### PR DESCRIPTION
This is the very same as defined in the subchart:

https://github.com/GaloyMoney/charts/blob/main/charts/galoy-pay/charts/galoy-nostr/values.yaml
