### PR TITLE
chore: switch to blink-nostr image

### DIFF
--- a/charts/galoy-pay/values.yaml
+++ b/charts/galoy-pay/values.yaml
@@ -23,8 +23,9 @@ galoy-nostr:
   enabled: true
   fullnameOverride: galoy-nostr
   image:
-    repository: krtk6160/galoy-nostr
-    digest: "sha256:cc82a694f81870c0becdc1b243ea9d4fca8b4ce497e70f4733d7b0539b462f19"
+    repository: us.gcr.io/galoy-org/blink-nostr
+    digest: "sha256:a5b1b1372b5d92295fdc19636302b732347cc5b69e763053cae68dbf96780266"
+    
 redis:
   redis0Dns: "galoy-redis-node-0.galoy-redis-headless"
   redis1Dns: "galoy-redis-node-1.galoy-redis-headless"


### PR DESCRIPTION
This is supporting the blinkbitcoinbot's PR for changing the galoy-nostr image digest.
First we need to change the repository of the image.
This PR does that. The edge-image currently has that sha256 digest.

Pull the image like:

```
docker pull us.gcr.io/galoy-org/blink-nostr:edge
```

See [this PR](https://github.com/GaloyMoney/charts/pull/7627) for an example of the blinbitcoinbot PRs.