### PR TITLE
chore: add k8s_events incl access rights to otel config

### DIFF
--- a/charts/galoy-deps/values.yaml
+++ b/charts/galoy-deps/values.yaml
@@ -36,6 +36,12 @@ opentelemetry-collector:
     - apiGroups: [""]
       resources: ["nodes/stats"]
       verbs: ["get"]
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["get", "list", "watch"]
+  presets:
+    kubernetesEvents:
+      enabled: true
   resources: {}
   mode: daemonset
   config:
@@ -149,6 +155,8 @@ opentelemetry-collector:
         auth_type: "serviceAccount"
         endpoint: "https://${env:K8S_NODE_NAME}:10250"
         insecure_skip_verify: true
+      k8s_events:
+        # No additional configuration needed for k8s_events
       jaeger:
         protocols:
           grpc:
@@ -172,11 +180,16 @@ opentelemetry-collector:
         logs:
           exporters:
             - debug
+            - otlp
           processors:
             - memory_limiter
+            - resourcedetection
+            - attributes
+            - k8sattributes
             - batch
           receivers:
             - otlp
+            - k8s_events
         metrics:
           exporters:
             - otlp


### PR DESCRIPTION
* `preset` to do most of the job
* Adding additional access right to avoid:
<details>

```
 W0429 13:51:26.139100       1 reflector.go:561] k8s.io/client-go@v0.31.3/tools/cache/reflector.go:243: failed to list *v1.Event: events is forbidden: User "system:serviceaccount:galoy-staging-otel:opentelemetry-collector" cannot list resource "events" in AP │
│ E0429 13:51:26.139163       1 reflector.go:158] "Unhandled Error" err="k8s.io/client-go@v0.31.3/tools/cache/reflector.go:243: Failed to watch *v1.Event: failed to list *v1.Event: events is forbidden: User \"system:serviceaccount:galoy-staging-otel:opentelem │
│ 2025-04-29T13:51:33.060Z    info    Traces    {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 2}                                                                                                                       │
│ 2025-04-29T13:51:38.213Z    info    Metrics    {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 29, "metrics": 326, "data points": 350}                                                                                          │
│ W0429 13:52:17.863644       1 reflector.go:561] k8s.io/client-go@v0.31.3/tools/cache/reflector.go:243: failed to list *v1.Event: events is forbidden: User "system:serviceaccount:galoy-staging-otel:opentelemetry-collector" cannot list resource "events" in AP │
│ E0429 13:52:17.863745       1 reflector.go:158] "Unhandled Error" err="k8s.io/client-go@v0.31.3/tools/cache/reflector.go:243: Failed to watch *v1.Event: failed to list *v1.Event: events is forbidden: User \"system:serviceaccount:galoy-staging-otel:opentelem │
│ 2025-04-29T13:52:38.058Z    info    Traces    {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 2}                                                                                                                       │
│ 2025-04-29T13:52:38.192Z    info    Metrics    {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 29, "metrics"
```

</details>
* configuring receiver, pipeline and exporter to properly treat those events.

Tested on staging by manual modifying the config.

For more context see:
https://github.com/blinkbitcoin/blink-wip/issues/88