### PR TITLE
feat: add withdrawalDescriptor option to bitcoind chart

### DIFF
--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -168,6 +168,47 @@ spec:
               mountPath: /data/.bitcoin/bitcoin.conf
               subPath: bitcoin.conf
         {{- end }}
+        {{- if and .Values.withdrawalDescriptor.secretName .Values.withdrawalDescriptor.secretKey }}
+        - name: withdrawal-descriptor-import
+          image: lncm/bitcoind:v27.0
+          command: ['/bin/sh']
+          args:
+          - '-c'
+          - |
+            echo "# Waiting for bitcoind to finish syncing"
+            while ! bitcoin-cli getblockchaininfo | grep '"initialblockdownload": false'; do
+              sleep 30
+            done
+            echo "# Checking for the withdrawal wallet"
+            if ! bitcoin-cli listwallets | grep "withdrawal"; then
+              if ! bitcoin-cli loadwallet "withdrawal"; then
+                echo "# Creating the withdrawal wallet"
+                bitcoin-cli createwallet "withdrawal" || exit 1
+              fi
+            fi
+            echo "# Checking for the withdrawal-descriptor"
+            descriptor_json=$(base64 -d </data/withdrawal-descriptors/descriptor_json_base64)
+            # extract the descriptor from the descriptor_json
+            desc=$(echo "${descriptor_json}" | cut -d'"' -f 6)
+            # derive the first address from the descriptor without importing it
+            derived_address=$(bitcoin-cli deriveaddresses "$desc" 0 | sed -n '2p' | cut -d'"' -f2)
+            # check if the address is already known to the withdrawal wallet
+            if ! bitcoin-cli -rpcwallet=withdrawal getaddressinfo "$derived_address" | grep '"ismine": true'; then
+              echo "# Importing the withdrawal-descriptor"
+              bitcoin-cli -rpcwallet=withdrawal importdescriptors "$descriptor_json" || exit 1
+            fi
+            echo "# The withdrawal-descriptor is present in the withdrawal wallet"
+            trap "echo shutting down; exit 0" SIGTERM
+            while true; do sleep 100; done
+          volumeMounts:
+            - name: bitcoind-withdrawal-descriptor
+              mountPath: /data/withdrawal-descriptors
+            - name: data
+              mountPath: /data/.bitcoin
+            - name: config
+              mountPath: /data/.bitcoin/bitcoin.conf
+              subPath: bitcoin.conf
+        {{- end }}
         - name: exporter
           image: jvstein/bitcoin-prometheus-exporter:v0.6.0
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -219,6 +260,14 @@ spec:
             secretName: {{ .Values.descriptor.secretName }}
             items:
             - key: {{ .Values.descriptor.secretKey }}
+              path: descriptor_json_base64
+        {{- end -}}
+        {{- if and .Values.withdrawalDescriptor.secretName .Values.withdrawalDescriptor.secretKey }}
+        - name: bitcoind-withdrawal-descriptor
+          secret:
+            secretName: {{ .Values.withdrawalDescriptor.secretName }}
+            items:
+            - key: {{ .Values.withdrawalDescriptor.secretKey }}
               path: descriptor_json_base64
         {{- end -}}
       {{- with .Values.nodeSelector }}

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -123,7 +123,13 @@ bitcoindCustomConfig:
   rpcbind: 0.0.0.0
   rpcallowip: 0.0.0.0/0
 
+# Optional configuration to create the "default" wallet
 descriptor:
+  secretName: ""
+  secretKey: ""
+
+# Optional configuration to create the "withdrawal" wallet
+withdrawalDescriptor:
   secretName: ""
   secretKey: ""
 


### PR DESCRIPTION
## Overview
The bitcoind chart now supports importing descriptors into two separate wallets:
- **Default wallet**: The original wallet for general operations
- **Withdrawal wallet**: A dedicated wallet specifically for withdrawal operations

Each wallet can be configured independently with its own descriptor secrets.

## Configuration
### Values.yaml Structure
```yaml
# Configuration for the default wallet descriptor
descriptor:
  secretName: "bitcoind-default-descriptor"
  secretKey: "descriptor_json_base64"

# Configuration for the withdrawal wallet descriptor  
withdrawalDescriptor:
  secretName: "bitcoind-withdrawal-descriptor"
  secretKey: "descriptor_json_base64"
```

### Configuration Options
#### Default Wallet (existing functionality)
- `descriptor.secretName`: Name of the Kubernetes secret containing the default wallet descriptor
- `descriptor.secretKey`: Key within the secret that contains the base64-encoded descriptor JSON

#### Withdrawal Wallet (new functionality)
- `withdrawalDescriptor.secretName`: Name of the Kubernetes secret containing the withdrawal wallet descriptor
- `withdrawalDescriptor.secretKey`: Key within the secret that contains the base64-encoded descriptor JSON

## Usage Examples
```yaml
descriptor:
  secretName: "bitcoind-default-descriptor"
  secretKey: "descriptor_json_base64"

withdrawalDescriptor:
  secretName: "bitcoind-withdrawal-descriptor"
  secretKey: "descriptor_json_base64"
```

## Implementation Details
### Wallet Creation
- The chart automatically creates both wallets if their respective descriptors are configured
- Wallets are created with names "default" and "withdrawal"
- Each wallet is independent and can be accessed via `bitcoin-cli -rpcwallet=<wallet_name>`

### Descriptor Import Process
1. Wait for bitcoind to finish initial block download
2. Check if the target wallet exists, create if necessary
3. Load the descriptor from the configured secret
4. Check if the descriptor is already imported (by deriving and checking the first address)
5. Import the descriptor if not already present

### Container Architecture
- Each wallet gets its own sidecar container for descriptor import
- Containers run independently and handle their own wallet lifecycle
- Both containers share the same bitcoind instance

## Security Considerations
- Each wallet can use different descriptor secrets for enhanced security separation
- Withdrawal operations can be isolated to the dedicated withdrawal wallet
- Default wallet can be used for general operations while keeping withdrawal keys separate

## Backward Compatibility
The implementation maintains full backward compatibility:
- Existing configurations with only `descriptor` settings continue to work unchanged
- No breaking changes to existing functionality
- New `withdrawalDescriptor` configuration is optional
