### PR TITLE
chore(deps): bump-lnd-backup-image-c8d61e0

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -11,8 +11,8 @@ sidecarImage:
 backupImage:
   repository: lnd-backup
   pullPolicy: IfNotPresent
-  digest: sha256:5d9f6da7db83976a5e8f10ad9d7cf6754dbaea1d50ec9773549e30a386eef749
-  git_ref: 5aec38a
+  digest: sha256:3127cae834858f0b560bc0646ac28cc5ba7fc142d27abeb5612830a426db8964
+  git_ref: c8d61e0
 kubemonkey:
   enabled: false
 configmap:
@@ -97,11 +97,10 @@ autoGenerateSeed:
   enabled: false
 autoGenerateTls:
   enabled: true
-
 # LND database configuration
 lnd:
   db:
-    backend: bbolt  # Options: bbolt, postgres
+    backend: bbolt # Options: bbolt, postgres
     config:
       # This secret should contain `uri` as the key for PostgreSQL connection string
       # Only required when backend is set to postgres
@@ -110,10 +109,9 @@ lnd:
       postgres:
         timeout: 0
         maxconnections: 21
-
 # PostgreSQL configuration
 postgresql:
-  enabled: false  # Set to true to deploy PostgreSQL
+  enabled: false # Set to true to deploy PostgreSQL
   auth:
     enablePostgresUser: false
     username: lnd


### PR DESCRIPTION
# Bump lnd-backup image

The lnd-backup image will be bumped to digest:
```
sha256:3127cae834858f0b560bc0646ac28cc5ba7fc142d27abeb5612830a426db8964
```

Code diff contained in this image:

https://github.com/blinkbitcoin/charts/compare/5aec38a...c8d61e0
