### PR TITLE
chore-bump-blink-terminal-image-647ef31

### DIFF
--- a/charts/blink-terminal/Chart.yaml
+++ b/charts/blink-terminal/Chart.yaml
@@ -3,7 +3,7 @@ name: blink-terminal
 description: A Helm chart for the blink-terminal (BlinkPOS) merchant terminal
 type: application
 version: 0.1.0-dev
-appVersion: 0.2.3
+appVersion: 0.2.5
 dependencies:
   - name: postgresql
     version: 18.5.2

--- a/charts/blink-terminal/values.yaml
+++ b/charts/blink-terminal/values.yaml
@@ -25,7 +25,7 @@ blinkTerminal:
   tracingServiceName: "blink-terminal"
 image:
   repository: us.gcr.io/galoy-org/blink-terminal
-  digest: "sha256:f905ff77db8455fc5c7e0a0ff77e7056d2eb34a5276a54c2ff7c7b37ecd7ef02" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=5541b76;app=blink-terminal;
+  digest: "sha256:c20542878d6fff713ed8d441c0e2993d75456e44459bc08da16fb44325ab3a68" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=647ef31;app=blink-terminal;
 ingress:
   enabled: false
 service:


### PR DESCRIPTION
# Bump blink-terminal image

The blink-terminal image will be bumped to digest:


Code diff contained in this image:

https://github.com/blinkbitcoin/blink-terminal/compare/5541b76...647ef31
