### PR TITLE
fix(blink-terminal): apply database migrations via init containers

### DIFF
--- a/charts/blink-terminal/templates/deployment.yaml
+++ b/charts/blink-terminal/templates/deployment.yaml
@@ -28,7 +28,19 @@ spec:
 {{ toYaml . | trim | indent 8 }}
 {{- end }}
     spec:
+      volumes:
+      - name: migrations
+        emptyDir: {}
       initContainers:
+      - name: copy-migrations
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        command:
+          - "sh"
+          - "-c"
+          - "cp -r /app/database/. /migrations/"
+        volumeMounts:
+        - name: migrations
+          mountPath: /migrations
       - name: wait-for-postgresql
         image: postgres
         command:
@@ -46,6 +58,44 @@ spec:
             secretKeyRef:
               name: {{ template "blink-terminal.fullname" . }}
               key: "database-url"
+      - name: run-migrations
+        image: postgres
+        command:
+          - "bash"
+          - "-c"
+          - |
+            set -euo pipefail
+            PSQL="psql -v ON_ERROR_STOP=1 -d $DATABASE_URL"
+
+            HAS_METRICS=$($PSQL -tAc "SELECT to_regclass('public.system_metrics') IS NOT NULL")
+            if [ "$HAS_METRICS" != "t" ]; then
+              echo "Running init.sql"
+              $PSQL -f /migrations/init.sql
+            fi
+
+            CURRENT=$($PSQL -tAc "SELECT COALESCE(MAX(metric_value::int), 0) FROM system_metrics WHERE metric_name = 'schema_version'")
+            echo "Current schema_version: $CURRENT"
+
+            for f in $(ls /migrations/migrations/*.sql | sort); do
+              N=$(basename "$f" | cut -d_ -f1 | sed 's/^0*//')
+              if [ "$N" -gt "$CURRENT" ]; then
+                echo "Applying migration $N: $f"
+                $PSQL -f "$f"
+              else
+                echo "Skipping $f (already at version $CURRENT)"
+              fi
+            done
+
+            echo "Migrations complete: schema_version=$($PSQL -tAc "SELECT MAX(metric_value::int) FROM system_metrics WHERE metric_name = 'schema_version'")"
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-terminal.fullname" . }}
+              key: "database-url"
+        volumeMounts:
+        - name: migrations
+          mountPath: /migrations
       containers:
       - name: blink-terminal
         image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"

--- a/charts/blink-terminal/templates/deployment.yaml
+++ b/charts/blink-terminal/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - name: migrations
           mountPath: /migrations
       - name: wait-for-postgresql
-        image: postgres
+        image: {{ .Values.psqlImage }}
         command:
           - "bash"
           - "-c"
@@ -61,7 +61,7 @@ spec:
               name: {{ template "blink-terminal.fullname" . }}
               key: "database-url"
       - name: run-migrations
-        image: postgres
+        image: {{ .Values.psqlImage }}
         command:
           - "bash"
           - "-c"

--- a/charts/blink-terminal/templates/deployment.yaml
+++ b/charts/blink-terminal/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app: {{ template "blink-terminal.fullname" . }}
       release: {{ .Release.Name }}
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/charts/blink-terminal/values.yaml
+++ b/charts/blink-terminal/values.yaml
@@ -26,6 +26,7 @@ blinkTerminal:
 image:
   repository: us.gcr.io/galoy-org/blink-terminal
   digest: "sha256:c20542878d6fff713ed8d441c0e2993d75456e44459bc08da16fb44325ab3a68" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=647ef31;app=blink-terminal;
+psqlImage: "postgres:15"
 ingress:
   enabled: false
 service:


### PR DESCRIPTION
## Problem

On first deploy of blink-terminal against an empty Cloud SQL database, the app crashes at runtime:

\`\`\`
[VoucherStore] getStats error: function update_expired_vouchers() does not exist
❌ Failed to expire old payments: error: relation "payment_splits" does not exist
\`\`\`

`payment_splits` and `update_expired_vouchers()` are introduced in `database/migrations/008_vouchers_table.sql`. Cloud SQL gives us an empty DB; the chart never applied `init.sql` or any of the 17 numbered migrations.

The legacy docker-compose flow (`deploy-prod.sh:306-360`) ran them via `docker-compose exec postgres psql < migrations/00X.sql` with `schema_version` gating — the chart had no equivalent.

Reported here: blinkbitcoin/blink-deployments#9470 (comment).

## Fix

Three init containers chain the same logic:

1. **`copy-migrations`** (blink-terminal image) — copies `/app/database/{init.sql,migrations/*.sql}` into a shared `emptyDir`. SQL files are already baked into the image via `Dockerfile:63 (COPY --from=builder /app/database ./database)`.
2. **`wait-for-postgresql`** (postgres image) — existing, unchanged.
3. **`run-migrations`** (postgres image) — `psql -f` against `$DATABASE_URL`. Runs `init.sql` if `system_metrics` table doesn't exist, then loops over `002_*.sql..NNN_*.sql` in numeric order and applies each whose number > current `MAX(schema_version)`.

Idempotent: a pod restart with no new migrations is a no-op.

## Why two images

The SQL files live in the **blink-terminal image** (Node-based, no `psql`). Running them requires `psql` from the **postgres image**. The shared `emptyDir` bridges them. Alternatives considered: install `postgresql-client` into the blink-terminal image (slower pod startup) or as a Helm hook Job (same bridging problem) — the init-container chain is the simplest cross-image solution.

## Verified

- `helm template charts/blink-terminal` renders 3 init containers in correct order before the app container.
- Schema-version gate logic mirrors `deploy-prod.sh`'s `if [ "$SCHEMA_VERSION" -lt N ]` checks; per-migration `schema_version` self-update is preserved (each `00X_*.sql` already inserts its own row).

## Test plan

- [ ] On a fresh staging deploy: `system_metrics` is created, all 17 migrations applied, schema_version = 18, `/api/health` returns 200, voucher operations work
- [ ] On an existing deploy with no new migrations: init containers report "Skipping" for each, app starts normally
- [ ] On a deploy adding a new migration `019_*.sql`: init container applies only #19, schema_version advances to 19