### PR TITLE
fix: switch bitnami chart repo from charts.bitnami.com to OCI registry

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get changed charts
         id: changed-charts
         run: |
-          changed=$(git diff --name-only origin/main...HEAD -- charts/ | cut -d'/' -f1-2 | sort -u)
+          changed=$(git diff --name-only origin/main...HEAD -- charts/ | cut -d'/' -f1-2 | sort -u | tr '\n' ' ')
           echo "charts<<EOF" >> $GITHUB_OUTPUT
           echo "$changed" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -30,7 +30,7 @@ jobs:
           repos=""
           for chart in ${{ steps.changed-charts.outputs.charts }}; do
             if [ -f "$chart/Chart.yaml" ]; then
-              repos="$repos $(grep 'repository:' "$chart/Chart.yaml" | awk '{print $2}' | tr -d '"' | grep '^https://')"
+              repos="$repos $(grep 'repository:' "$chart/Chart.yaml" | awk '{print $2}' | tr -d '"' | grep '^https://' || true)"
             fi
           done
           i=0
@@ -47,7 +47,7 @@ jobs:
           for chart in ${{ steps.changed-charts.outputs.charts }}; do
             if [ -f "$chart/Chart.yaml" ]; then
               echo "Linting $chart..."
-              helm dependency build "$chart"
+              helm dependency update "$chart"
               helm lint "$chart"
             fi
           done
@@ -60,4 +60,3 @@ jobs:
               helm template test "$chart"
             fi
           done
-

--- a/charts/blink-terminal/Chart.lock
+++ b/charts/blink-terminal/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
-digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
-generated: "2026-03-24T17:47:15.669389+01:00"
+digest: sha256:befdec60be4116d9911aacc60b1066acaf41cd9d45f7adcdd83133c7395d0c5e
+generated: "2026-05-05T18:39:21.005146+02:00"

--- a/charts/blink-terminal/Chart.lock
+++ b/charts/blink-terminal/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
 generated: "2026-03-24T17:47:15.669389+01:00"

--- a/charts/blink-terminal/Chart.yaml
+++ b/charts/blink-terminal/Chart.yaml
@@ -7,5 +7,5 @@ appVersion: 0.2.8
 dependencies:
   - name: postgresql
     version: 18.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled

--- a/charts/bria/Chart.lock
+++ b/charts/bria/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
 generated: "2026-03-04T11:29:12.569314004Z"

--- a/charts/bria/Chart.lock
+++ b/charts/bria/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
-digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
-generated: "2026-03-04T11:29:12.569314004Z"
+digest: sha256:befdec60be4116d9911aacc60b1066acaf41cd9d45f7adcdd83133c7395d0c5e
+generated: "2026-05-05T18:39:41.093179+02:00"

--- a/charts/bria/Chart.yaml
+++ b/charts/bria/Chart.yaml
@@ -22,5 +22,5 @@ appVersion: 0.1.138
 dependencies:
   - name: postgresql
     version: 18.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled

--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: price
   repository: ""
   version: 0.1.0
-digest: sha256:9d7682e59d33e93724537499898bf6623b35caef429c71408c36316e1f0642f0
-generated: "2026-03-12T15:31:02.470121+01:00"
+digest: sha256:66cfefae16d386f33e54beca901aab54114e29901bf60d709dc69bfc2ef6e0df
+generated: "2026-05-05T18:40:00.681892+02:00"

--- a/charts/galoy/Chart.lock
+++ b/charts/galoy/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 20.11.3
 - name: mongodb
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.6.26
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 - name: oathkeeper
   repository: https://k8s.ory.sh/helm/charts

--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -19,13 +19,13 @@ version: 0.34.7-dev
 appVersion: 0.22.2
 dependencies:
   - name: redis
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 20.11.3
   - name: mongodb
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 15.6.26
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 18.5.2
     condition: postgresql.enabled
   - name: oathkeeper

--- a/charts/lnd/Chart.lock
+++ b/charts/lnd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 - name: lndmon
   repository: ""

--- a/charts/lnd/Chart.lock
+++ b/charts/lnd/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: lndmon
   repository: ""
   version: x.x.x
-digest: sha256:5c18b616c4e5c243ff8908d0cec7ab84b246b31f3198877c6d9e9546485b129b
-generated: "2026-03-04T11:29:17.002474602Z"
+digest: sha256:2644dad3b0d7399f18954ac583a8f3a03f5a692dcf60542c167f59b871f38fd6
+generated: "2026-05-05T18:41:37.578043+02:00"

--- a/charts/lnd/Chart.yaml
+++ b/charts/lnd/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     email: dev@blink.sv
 dependencies:
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 18.5.2
     condition: postgresql.enabled
   - name: lndmon

--- a/charts/stablesats/Chart.lock
+++ b/charts/stablesats/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
-digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
-generated: "2026-03-04T11:29:15.587467155Z"
+digest: sha256:befdec60be4116d9911aacc60b1066acaf41cd9d45f7adcdd83133c7395d0c5e
+generated: "2026-05-05T18:42:34.64874+02:00"

--- a/charts/stablesats/Chart.lock
+++ b/charts/stablesats/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
 generated: "2026-03-04T11:29:15.587467155Z"

--- a/charts/stablesats/Chart.yaml
+++ b/charts/stablesats/Chart.yaml
@@ -7,5 +7,5 @@ appVersion: 0.12.11
 dependencies:
   - name: postgresql
     version: 18.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled

--- a/charts/voucher/Chart.lock
+++ b/charts/voucher/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
 digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
 generated: "2026-03-04T11:29:10.572497847Z"

--- a/charts/voucher/Chart.lock
+++ b/charts/voucher/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.5.2
-digest: sha256:0059f5f5f14d99cc4ebf9fc1c203139bad23c6ab9b541d136181e94603787d19
-generated: "2026-03-04T11:29:10.572497847Z"
+digest: sha256:befdec60be4116d9911aacc60b1066acaf41cd9d45f7adcdd83133c7395d0c5e
+generated: "2026-05-05T18:42:55.102977+02:00"

--- a/charts/voucher/Chart.yaml
+++ b/charts/voucher/Chart.yaml
@@ -21,5 +21,5 @@ appVersion: 0.1.0
 dependencies:
   - name: postgresql
     version: 18.5.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled


### PR DESCRIPTION
## Summary
- switch Bitnami chart dependencies from `https://charts.bitnami.com/bitnami` to `oci://registry-1.docker.io/bitnamicharts`
- update matching `Chart.lock` repository entries without regenerating digests

## Notes
- `helm_release` has `dependency_update = true`, so locks can regenerate during deploy resolution
- image repository overrides are unchanged
