### PR TITLE
fix(galoy): wait for testflight helm jobs

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -431,6 +431,7 @@ resource "helm_release" "galoy" {
 
   dependency_update = true
   timeout           = 900
+  wait_for_jobs     = true
 }
 
 data "google_container_cluster" "primary" {


### PR DESCRIPTION
Ensure the Galoy testflight Helm release waits for migration jobs before continuing. This prevents Kratos from starting against an unmigrated Postgres schema during CI.