### PR TITLE
feat: add blink-lnurl-server chart

### DIFF
--- a/charts/blink-lnurl-server/.helmignore
+++ b/charts/blink-lnurl-server/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/blink-lnurl-server/.helmignore
+++ b/charts/blink-lnurl-server/.helmignore
@@ -1,5 +1,8 @@
 # Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
 .DS_Store
+# Common VCS dirs
 .git/
 .gitignore
 .bzr/
@@ -7,11 +10,13 @@
 .hg/
 .hgignore
 .svn/
+# Common backup files
 *.swp
 *.bak
 *.tmp
 *.orig
 *~
+# Various IDEs
 .project
 .idea/
 *.tmproj

--- a/charts/blink-lnurl-server/Chart.yaml
+++ b/charts/blink-lnurl-server/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: blink-lnurl-server
+description: A Helm chart for blink-lnurl-server
+type: application
+version: 0.1.0-dev
+appVersion: 0.2.0

--- a/charts/blink-lnurl-server/Chart.yaml
+++ b/charts/blink-lnurl-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: blink-lnurl-server
-description: A Helm chart for blink-lnurl-server
+description: A Helm chart for Blink LNURL Server
 type: application
 version: 0.1.0-dev
 appVersion: 0.2.0

--- a/charts/blink-lnurl-server/templates/_helpers.tpl
+++ b/charts/blink-lnurl-server/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "blink-lnurl-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/blink-lnurl-server/templates/_helpers.tpl
+++ b/charts/blink-lnurl-server/templates/_helpers.tpl
@@ -15,3 +15,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve the webhook domain required by the app at startup.
+*/}}
+{{- define "blink-lnurl-server.webhookDomain" -}}
+{{- $webhookDomain := .Values.blinkLnurlServer.webhookDomain | default "" -}}
+{{- if $webhookDomain -}}
+{{- $webhookDomain -}}
+{{- else -}}
+{{- $domains := .Values.blinkLnurlServer.domains | default "" -}}
+{{- $firstDomain := splitList "," $domains | first | trim -}}
+{{- required "blinkLnurlServer.webhookDomain or blinkLnurlServer.domains is required" $firstDomain -}}
+{{- end -}}
+{{- end -}}

--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -56,10 +56,8 @@ spec:
           value: {{ .Values.blinkLnurlServer.network | quote }}
         - name: LNURL_SCHEME
           value: {{ .Values.blinkLnurlServer.scheme | quote }}
-{{- if .Values.blinkLnurlServer.webhookDomain }}
         - name: LNURL_WEBHOOK_DOMAIN
-          value: {{ .Values.blinkLnurlServer.webhookDomain | quote }}
-{{- end }}
+          value: {{ include "blink-lnurl-server.webhookDomain" . | quote }}
         - name: LNURL_LOG_LEVEL
           value: {{ .Values.blinkLnurlServer.logLevel | quote }}
         - name: LNURL_MIN_SENDABLE

--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -56,8 +56,10 @@ spec:
           value: {{ .Values.blinkLnurlServer.network | quote }}
         - name: LNURL_SCHEME
           value: {{ .Values.blinkLnurlServer.scheme | quote }}
+{{- if .Values.blinkLnurlServer.webhookDomain }}
         - name: LNURL_WEBHOOK_DOMAIN
           value: {{ .Values.blinkLnurlServer.webhookDomain | quote }}
+{{- end }}
         - name: LNURL_LOG_LEVEL
           value: {{ .Values.blinkLnurlServer.logLevel | quote }}
         - name: LNURL_MIN_SENDABLE
@@ -66,8 +68,10 @@ spec:
           value: {{ .Values.blinkLnurlServer.maxSendable | quote }}
         - name: LNURL_WEBHOOK_DELIVERY_TTL_DAYS
           value: {{ .Values.blinkLnurlServer.webhookDeliveryTtlDays | quote }}
+{{- if .Values.blinkLnurlServer.crlUrl }}
         - name: LNURL_CRL_URL
           value: {{ .Values.blinkLnurlServer.crlUrl | quote }}
+{{- end }}
         - name: LNURL_DB_URL
           valueFrom:
             secretKeyRef:

--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "blink-lnurl-server.fullname" . }}
+  labels:
+    app: {{ template "blink-lnurl-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    kube-monkey/identifier: {{ template "blink-lnurl-server.fullname" . }}
+    kube-monkey/enabled: enabled
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "3"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "blink-lnurl-server.fullname" . }}
+      release: {{ .Release.Name }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "blink-lnurl-server.fullname" . }}
+        release: "{{ .Release.Name }}"
+        kube-monkey/identifier: {{ template "blink-lnurl-server.fullname" . }}
+        kube-monkey/enabled: enabled
+{{- with .Values.labels }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: blink-lnurl-server
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 30
+        env:
+        - name: LNURL_ADDRESS
+          value: {{ .Values.blinkLnurlServer.address | quote }}
+        - name: LNURL_AUTO_MIGRATE
+          value: {{ .Values.blinkLnurlServer.autoMigrate | quote }}
+        - name: LNURL_DOMAINS
+          value: {{ .Values.blinkLnurlServer.domains | quote }}
+        - name: LNURL_NETWORK
+          value: {{ .Values.blinkLnurlServer.network | quote }}
+        - name: LNURL_SCHEME
+          value: {{ .Values.blinkLnurlServer.scheme | quote }}
+        - name: LNURL_WEBHOOK_DOMAIN
+          value: {{ .Values.blinkLnurlServer.webhookDomain | quote }}
+        - name: LNURL_LOG_LEVEL
+          value: {{ .Values.blinkLnurlServer.logLevel | quote }}
+        - name: LNURL_MIN_SENDABLE
+          value: {{ .Values.blinkLnurlServer.minSendable | quote }}
+        - name: LNURL_MAX_SENDABLE
+          value: {{ .Values.blinkLnurlServer.maxSendable | quote }}
+        - name: LNURL_WEBHOOK_DELIVERY_TTL_DAYS
+          value: {{ .Values.blinkLnurlServer.webhookDeliveryTtlDays | quote }}
+        - name: LNURL_CRL_URL
+          value: {{ .Values.blinkLnurlServer.crlUrl | quote }}
+        - name: LNURL_DB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-lnurl-server.fullname" . }}
+              key: "db-url"
+        - name: LNURL_SSP_AUTH_SEED
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-lnurl-server.fullname" . }}
+              key: "ssp-auth-seed"
+        - name: LNURL_NSEC
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-lnurl-server.fullname" . }}
+              key: "nsec"
+              optional: true
+        - name: LNURL_CA_CERT
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-lnurl-server.fullname" . }}
+              key: "ca-cert"
+              optional: true
+        resources:
+          {{ toYaml .Values.resources | nindent 10 }}

--- a/charts/blink-lnurl-server/templates/ingress.yaml
+++ b/charts/blink-lnurl-server/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "blink-lnurl-server.fullname" . }}
+  labels:
+    app: {{ include "blink-lnurl-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
+spec:
+  ingressClassName: nginx
+  rules:
+    {{- if .Values.ingress.rulesOverride }}
+    {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: {{ include "blink-lnurl-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+    {{- end -}}
+    {{- end }}
+  tls:
+    {{- range .Values.ingress.hosts }}
+    - hosts:
+      - {{ . }}
+      secretName: {{ printf "%s-tls" . }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/blink-lnurl-server/templates/secrets.yaml
+++ b/charts/blink-lnurl-server/templates/secrets.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "blink-lnurl-server.fullname" . }}
+  labels:
+    app: {{ template "blink-lnurl-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  db-url: {{ .Values.secrets.dbUrl | b64enc | quote }}
+  ssp-auth-seed: {{ .Values.secrets.sspAuthSeed | b64enc | quote }}
+  {{- if .Values.secrets.nsec }}
+  nsec: {{ .Values.secrets.nsec | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.caCert }}
+  ca-cert: {{ .Values.secrets.caCert | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/blink-lnurl-server/templates/service.yaml
+++ b/charts/blink-lnurl-server/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "blink-lnurl-server.fullname" . }}
+  labels:
+    app: {{ template "blink-lnurl-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "blink-lnurl-server.fullname" . }}

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -20,7 +20,7 @@ blinkLnurlServer:
 
 image:
   repository: us.gcr.io/galoy-org/blink-lnurl-server
-  digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000" # METADATA:: repository=https://github.com/blinkbitcoin/blink-lnurl-server;commit_ref=initial;app=blink-lnurl-server;
+  digest: "sha256:3ea495eb08546a2c9b1c7733562c6611ae4b2ab921e1ab868bc0d61f4c22bab2" # METADATA:: repository=https://github.com/blinkbitcoin/blink-lnurl-server;commit_ref=2cb265b;app=blink-lnurl-server;
 
 ingress:
   enabled: false

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -8,7 +8,7 @@ secrets:
 blinkLnurlServer:
   address: "0.0.0.0:8080"
   autoMigrate: "true"
-  domains: ""
+  domains: "localhost:8080"
   network: "mainnet"
   scheme: "https"
   webhookDomain: ""

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -1,0 +1,35 @@
+secrets:
+  create: true
+  dbUrl: ""
+  sspAuthSeed: ""
+  nsec: ""
+  caCert: ""
+
+blinkLnurlServer:
+  address: "0.0.0.0:8080"
+  autoMigrate: "true"
+  domains: ""
+  network: "mainnet"
+  scheme: "https"
+  webhookDomain: ""
+  logLevel: "info"
+  minSendable: "1000"
+  maxSendable: "4000000000"
+  webhookDeliveryTtlDays: "90"
+  crlUrl: ""
+
+image:
+  repository: us.gcr.io/galoy-org/blink-lnurl-server
+  digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000" # METADATA:: repository=https://github.com/blinkbitcoin/blink-lnurl-server;commit_ref=initial;app=blink-lnurl-server;
+
+ingress:
+  enabled: false
+  hosts: []
+  rulesOverride: null
+  extraTls: []
+
+service:
+  port: 8080
+  type: ClusterIP
+
+resources: {}

--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -75,6 +75,8 @@ config:
 
 #@ addons_charts = ["admin-panel", "galoy-pay", "api-dashboard", "map", "voucher", "blink-terminal"]
 
+#@ noncust_charts = ["blink-lnurl-server"]
+
 #@ def testflight_job(chart, deployment, vars = {}):
 name: #@ testflight_job_name(chart)
 plan:

--- a/ci/pipeline-fragments.lib.yml
+++ b/ci/pipeline-fragments.lib.yml
@@ -83,13 +83,11 @@ plan:
 - in_parallel:
   - get: #@ chart_resource_name(chart)
     trigger: true
-  - { get: pipeline-tasks }
 - task: prepare-testflight
   config:
     platform: linux
     image_resource: #@ task_image_config()
     inputs:
-    - name: pipeline-tasks
     - name: #@ chart_resource_name(chart)
       path: repo
     outputs:
@@ -97,7 +95,7 @@ plan:
     params:
       CHART: #@ chart
     run:
-      path: pipeline-tasks/ci/tasks/prepare-testflight.sh
+      path: repo/ci/tasks/prepare-testflight.sh
 - put: #@ "tf-" + chart + "-testflight"
   tags:
     - #@ data.values.staging_worker_tag
@@ -191,6 +189,7 @@ source:
   - #@ "charts/" + chart_name + "/*"
   - #@ "charts/" + chart_name + "/**/*"
   - #@ "ci/tasks/" + chart_name + "-smoketest.sh"
+  - ci/tasks/prepare-testflight.sh
   - #@ "ci/testflight/" + chart_name + "/*"
   - #@ "ci/tasks/get-smoketest-settings.sh"
   uri: #@ data.values.git_uri

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -17,6 +17,7 @@
 #@   "monitoring_charts",
 #@   "bitcoin_charts",
 #@   "addons_charts",
+#@   "noncust_charts",
 #@   "task_image_config",
 #@   "repo_resource",
 #@   "build_task")
@@ -60,6 +61,12 @@ groups:
   - #@ testflight_job_name(chart)
   - #@ bump_in_deployments_job_name(chart)
 #@ end
+- name: noncust
+  jobs:
+#@ for chart in noncust_charts:
+  - #@ testflight_job_name(chart)
+  - #@ bump_in_deployments_job_name(chart)
+#@ end
 - name: all
   jobs:
   - galoy-testflight
@@ -73,6 +80,10 @@ groups:
   - #@ bump_in_deployments_job_name(chart)
 #@ end
 #@ for chart in addons_charts:
+  - #@ testflight_job_name(chart)
+  - #@ bump_in_deployments_job_name(chart)
+#@ end
+#@ for chart in noncust_charts:
   - #@ testflight_job_name(chart)
   - #@ bump_in_deployments_job_name(chart)
 #@ end
@@ -107,6 +118,10 @@ jobs:
 #@ end
 #@ for chart in addons_charts:
 - #@ testflight_job(chart, "addons")
+- #@ bump_in_deployments_job(chart)
+#@ end
+#@ for chart in noncust_charts:
+- #@ testflight_job(chart, "noncust")
 - #@ bump_in_deployments_job(chart)
 #@ end
 - #@ testflight_job("galoy", "galoy", galoy_chart_vars())
@@ -397,6 +412,11 @@ resources:
 #@ end
 
 #@ for chart in addons_charts:
+- #@ chart_repo_resource(chart)
+- #@ testflight_tf_resource(chart)
+#@ end
+
+#@ for chart in noncust_charts:
 - #@ chart_repo_resource(chart)
 - #@ testflight_tf_resource(chart)
 #@ end

--- a/ci/repipe
+++ b/ci/repipe
@@ -53,6 +53,11 @@ DEPS_DIR=$(mktemp -d -t deps.XXXXXX)
 
 for d in */ ; do
   pushd $d > /dev/null
+  if [[ ! -f Chart.yaml ]]; then
+    popd > /dev/null
+    continue
+  fi
+
   TMPFILE=$(mktemp /tmp/helm-update.XXXXXXX) || exit 1
 
   helm dependency list | grep -v WARNING | sort | uniq | tail -n +2 | awk '{ print $1, $3 }'> $TMPFILE
@@ -67,7 +72,7 @@ for d in */ ; do
     dep=$(echo $p | cut -d' ' -f1)
     repo=$(echo $p | cut -d' ' -f2)
 
-    if [[ $(echo $repo | grep http) == "" ]]; then continue; fi
+    if [[ ! "$repo" =~ ^(https?://|oci://) ]]; then continue; fi
 
     foldername=$(echo $DEPS_DIR/$dep-$(echo $repo | shasum -a 256 | head -c 10))
     mkdir -p $foldername

--- a/ci/tasks/blink-lnurl-server-smoketest.sh
+++ b/ci/tasks/blink-lnurl-server-smoketest.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu
+
+source smoketest-settings/helpers.sh
+
+host=`setting "blink_lnurl_server_endpoint"`
+port=`setting "blink_lnurl_server_port"`
+
+success="false"
+set +e
+for i in {1..15}; do
+  echo "Attempt ${i} to curl blink-lnurl-server health"
+  curl --location -f "${host}:${port}/health"
+  if [[ $? == 0 ]]; then success="true"; break; fi;
+  sleep 1
+done
+set -e
+
+if [[ "$success" != "true" ]]; then
+  echo "Health smoke test failed"
+  exit 1
+fi
+
+status=$(curl --location --silent --output /tmp/blink-lnurl-server-smoketest-body --write-out "%{http_code}" "${host}:${port}/.well-known/lnurlp/__smoketest__" || true)
+if [[ "$status" == "200" || "$status" == "404" ]]; then
+  exit 0
+fi
+
+if grep -Eiq "not.?found|domain|user|identifier" /tmp/blink-lnurl-server-smoketest-body; then
+  exit 0
+fi
+
+echo "LNURL discovery smoke test failed with HTTP status ${status}"
+cat /tmp/blink-lnurl-server-smoketest-body
+exit 1

--- a/ci/tasks/prepare-testflight.sh
+++ b/ci/tasks/prepare-testflight.sh
@@ -4,7 +4,11 @@ set -eu
 
 echo "Preparing testflight"
 
-cp -r pipeline-tasks/ci/testflight/${CHART} testflight/tf
+if [[ -d "repo/ci/testflight/${CHART}" ]]; then
+  cp -r "repo/ci/testflight/${CHART}" testflight/tf
+else
+  cp -r "pipeline-tasks/ci/testflight/${CHART}" testflight/tf
+fi
 cp -r repo/charts/${CHART} testflight/tf/chart
 
 cat <<EOF > testflight/tf/terraform.tfvars

--- a/ci/testflight/blink-lnurl-server/main.tf
+++ b/ci/testflight/blink-lnurl-server/main.tf
@@ -26,7 +26,8 @@ resource "random_password" "postgresql" {
 resource "helm_release" "postgresql" {
   name       = "blink-lnurl-server-postgresql"
   chart      = "postgresql"
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
+  version    = "18.5.2"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [

--- a/ci/testflight/blink-lnurl-server/main.tf
+++ b/ci/testflight/blink-lnurl-server/main.tf
@@ -1,0 +1,124 @@
+variable "testflight_namespace" {}
+
+locals {
+  cluster_name     = "galoy-staging-cluster"
+  cluster_location = "us-east1"
+  gcp_project      = "galoy-staging"
+
+  smoketest_namespace  = "galoy-staging-smoketest"
+  testflight_namespace = var.testflight_namespace
+
+  service_name = "blink-lnurl-server"
+  service_host = "${local.service_name}.${local.testflight_namespace}.svc.cluster.local"
+}
+
+resource "kubernetes_namespace" "testflight" {
+  metadata {
+    name = local.testflight_namespace
+  }
+}
+
+resource "random_password" "postgresql" {
+  length  = 20
+  special = false
+}
+
+resource "helm_release" "postgresql" {
+  name       = "blink-lnurl-server-postgresql"
+  chart      = "postgresql"
+  repository = "https://charts.bitnami.com/bitnami"
+  namespace  = kubernetes_namespace.testflight.metadata[0].name
+
+  values = [
+    file("${path.module}/postgresql-values.yml")
+  ]
+
+  set {
+    name  = "auth.password"
+    value = random_password.postgresql.result
+  }
+}
+
+resource "kubernetes_secret" "blink_lnurl_server" {
+  metadata {
+    name      = "blink-lnurl-server"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+
+  data = {
+    "db-url"        = "postgres://lnurl:${random_password.postgresql.result}@blink-lnurl-server-postgresql:5432/lnurl"
+    "ssp-auth-seed" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}
+
+resource "kubernetes_secret" "smoketest" {
+  metadata {
+    name      = local.testflight_namespace
+    namespace = local.smoketest_namespace
+  }
+  data = {
+    blink_lnurl_server_endpoint = local.service_host
+    blink_lnurl_server_port     = 8080
+  }
+}
+
+resource "helm_release" "blink_lnurl_server" {
+  name      = local.service_name
+  chart     = "${path.module}/chart"
+  namespace = kubernetes_namespace.testflight.metadata[0].name
+
+  values = [
+    templatefile("${path.module}/testflight-values.yml", {
+      service_host : local.service_host
+    })
+  ]
+
+  depends_on = [
+    helm_release.postgresql,
+    kubernetes_secret.blink_lnurl_server,
+  ]
+}
+
+data "google_container_cluster" "primary" {
+  project  = local.gcp_project
+  name     = local.cluster_name
+  location = local.cluster_location
+}
+
+data "google_client_config" "default" {
+}
+
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.primary.private_cluster_config.0.private_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.google_container_cluster.primary.private_cluster_config.0.private_endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "7.11.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/ci/testflight/blink-lnurl-server/postgresql-values.yml
+++ b/ci/testflight/blink-lnurl-server/postgresql-values.yml
@@ -1,0 +1,10 @@
+auth:
+  username: lnurl
+  database: lnurl
+
+primary:
+  resources:
+    limits: {}
+    requests:
+      memory: 256Mi
+      cpu: 100m

--- a/ci/testflight/blink-lnurl-server/testflight-values.yml
+++ b/ci/testflight/blink-lnurl-server/testflight-values.yml
@@ -1,0 +1,10 @@
+secrets:
+  create: false
+
+blinkLnurlServer:
+  domains: "${service_host}:8080"
+  network: "regtest"
+  scheme: "http"
+  webhookDomain: "${service_host}:8080"
+  logLevel: "debug"
+  autoMigrate: "true"

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -4,6 +4,7 @@ include('./monitoring/Tiltfile')
 include('./galoy/Tiltfile')
 include('./addons/Tiltfile')
 include('./stablesats/Tiltfile')
+include('./noncust/Tiltfile')
 include('./kafka-connect/Tiltfile')
 include('./smoketest/Tiltfile')
 

--- a/dev/noncust/Tiltfile
+++ b/dev/noncust/Tiltfile
@@ -8,6 +8,7 @@ noncust_namespace = '{}-noncust'.format(name_prefix)
 smoketest_namespace = '{}-smoketest'.format(name_prefix)
 
 namespace_create(noncust_namespace)
+namespace_create(smoketest_namespace)
 
 local('helm repo add bitnami https://charts.bitnami.com/bitnami')
 
@@ -26,7 +27,7 @@ k8s_yaml(secret_from_dict(
   namespace=noncust_namespace,
   inputs={
     'db-url': 'postgres://lnurl:lnurl@blink-lnurl-server-postgresql.{}.svc.cluster.local:5432/lnurl'.format(noncust_namespace),
-    'ssp-auth-seed': '0000000000000000000000000000000000000000000000000000000000000000',
+    'ssp-auth-seed': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   }
 ))
 

--- a/dev/noncust/Tiltfile
+++ b/dev/noncust/Tiltfile
@@ -8,7 +8,7 @@ noncust_namespace = '{}-noncust'.format(name_prefix)
 smoketest_namespace = '{}-smoketest'.format(name_prefix)
 
 namespace_create(noncust_namespace)
-namespace_create(smoketest_namespace)
+namespace_create(smoketest_namespace, allow_duplicates=True)
 
 local('helm repo add bitnami https://charts.bitnami.com/bitnami')
 

--- a/dev/noncust/Tiltfile
+++ b/dev/noncust/Tiltfile
@@ -1,0 +1,54 @@
+load('ext://namespace', 'namespace_create')
+load('ext://secret', 'secret_from_dict')
+load('ext://helm_resource', 'helm_resource')
+load('../common/Tiltfile', 'helm_release')
+
+name_prefix = 'galoy-dev'
+noncust_namespace = '{}-noncust'.format(name_prefix)
+smoketest_namespace = '{}-smoketest'.format(name_prefix)
+
+namespace_create(noncust_namespace)
+
+local('helm repo add bitnami https://charts.bitnami.com/bitnami')
+
+helm_resource(
+  name='blink-lnurl-server-postgresql',
+  chart='bitnami/postgresql',
+  namespace=noncust_namespace,
+  flags=[
+    '--values=./postgresql-values.yml',
+  ],
+  labels='noncust'
+)
+
+k8s_yaml(secret_from_dict(
+  name='blink-lnurl-server',
+  namespace=noncust_namespace,
+  inputs={
+    'db-url': 'postgres://lnurl:lnurl@blink-lnurl-server-postgresql.{}.svc.cluster.local:5432/lnurl'.format(noncust_namespace),
+    'ssp-auth-seed': '0000000000000000000000000000000000000000000000000000000000000000',
+  }
+))
+
+helm_release(
+  '../../charts/blink-lnurl-server',
+  name='blink-lnurl-server',
+  namespace=noncust_namespace,
+  values=['./blink-lnurl-server-values.yml'],
+)
+
+k8s_resource(
+  workload='blink-lnurl-server',
+  labels='noncust',
+  resource_deps=['blink-lnurl-server-postgresql'],
+  port_forwards=8080,
+)
+
+k8s_yaml(secret_from_dict(
+  name='blink-lnurl-server-smoketest',
+  namespace=smoketest_namespace,
+  inputs={
+    'blink_lnurl_server_endpoint': 'blink-lnurl-server.{}.svc.cluster.local'.format(noncust_namespace),
+    'blink_lnurl_server_port': '8080',
+  }
+))

--- a/dev/noncust/blink-lnurl-server-values.yml
+++ b/dev/noncust/blink-lnurl-server-values.yml
@@ -1,0 +1,9 @@
+secrets:
+  create: false
+
+blinkLnurlServer:
+  domains: "blink-lnurl-server.galoy-dev-noncust.svc.cluster.local:8080"
+  network: "regtest"
+  scheme: "http"
+  webhookDomain: "blink-lnurl-server.galoy-dev-noncust.svc.cluster.local:8080"
+  logLevel: "debug"

--- a/dev/noncust/postgresql-values.yml
+++ b/dev/noncust/postgresql-values.yml
@@ -1,0 +1,14 @@
+# Settings from:
+# https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+
+image:
+  repository: bitnamilegacy/postgresql
+
+auth:
+  enablePostgresUser: false
+  username: lnurl
+  password: lnurl
+  database: lnurl
+
+persistence:
+  enabled: false

--- a/dev/smoketest/Tiltfile
+++ b/dev/smoketest/Tiltfile
@@ -4,7 +4,7 @@ load('ext://secret', 'secret_from_dict')
 name_prefix = 'galoy-dev'
 smoketest_namespace = '{}-smoketest'.format(name_prefix)
 
-namespace_create(smoketest_namespace)
+namespace_create(smoketest_namespace, allow_duplicates=True)
 
 smoketest_role_yaml="""
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Adds a deployable Helm chart, chart-level smoketest, charts CI/testflight wiring, and local Tilt dev setup for `blink-lnurl-server`.

This chart is for the REST/LNURL service only. It does not add GraphQL subgraph files, Apollo Router config, or deployment-repo Terraform wiring. Those are tracked separately under blinkbitcoin/blink-wip#786.

## What changed

- Added `charts/blink-lnurl-server` with:
  - `Chart.yaml`
  - `values.yaml`
  - deployment, service, ingress, secret, and helper templates
- Added `ci/tasks/blink-lnurl-server-smoketest.sh`.
- Added charts CI/testflight wiring:
  - `noncust` chart group in `ci/pipeline.yml`
  - `noncust_charts = ["blink-lnurl-server"]`
  - `blink-lnurl-server-testflight`
  - `bump-blink-lnurl-server-in-deployments`
  - `ci/testflight/blink-lnurl-server`
- Added `dev/noncust` Tilt dev setup:
  - local `galoy-dev-noncust` namespace
  - Bitnami PostgreSQL release for local development
  - development values for `blink-lnurl-server`
  - smoketest secret for the existing smoketest task pattern
- Included `dev/noncust/Tiltfile` from the root `dev/Tiltfile`.
- Exposes the service on port `8080` through a `ClusterIP` service.
- Adds readiness and liveness probes against `GET /health`.
- Uses the public image repository:
  - `us.gcr.io/galoy-org/blink-lnurl-server`
- Uses a verified initial image digest:
  - `sha256:3ea495eb08546a2c9b1c7733562c6611ae4b2ab921e1ab868bc0d61f4c22bab2`

## Runtime configuration

Non-sensitive runtime configuration is exposed through `blinkLnurlServer` values:

- `LNURL_ADDRESS`
- `LNURL_AUTO_MIGRATE`
- `LNURL_DOMAINS`
- `LNURL_NETWORK`
- `LNURL_SCHEME`
- `LNURL_WEBHOOK_DOMAIN`
- `LNURL_LOG_LEVEL`
- `LNURL_MIN_SENDABLE`
- `LNURL_MAX_SENDABLE`
- `LNURL_WEBHOOK_DELIVERY_TTL_DAYS`
- `LNURL_CRL_URL`

`LNURL_WEBHOOK_DOMAIN` is always rendered because the app requires it at startup. It uses `blinkLnurlServer.webhookDomain` when set, otherwise it falls back to the first entry in `blinkLnurlServer.domains`. Helm fails with a clear error if both values are empty.

`LNURL_CRL_URL` is only rendered when non-empty. It is an optional application arg, and passing an empty env var could produce malformed runtime behavior.

Sensitive runtime configuration is read from a Kubernetes Secret:

- `LNURL_DB_URL` from `db-url`
- `LNURL_SSP_AUTH_SEED` from `ssp-auth-seed`
- `LNURL_NSEC` from optional key `nsec`
- `LNURL_CA_CERT` from optional key `ca-cert`

The optional `LNURL_NSEC` and `LNURL_CA_CERT` refs are rendered with `optional: true`. This allows deployment code to provide externally managed optional secret keys without putting optional secret values into Helm values.

## Ingress

The ingress template follows the existing `api-dashboard` / `blink-terminal` pattern:

- Controlled by `ingress.enabled`.
- Uses `ingressClassName: nginx`.
- Adds `cert-manager.io/cluster-issuer: letsencrypt-issuer`.
- Routes prefix `/` to service port `8080`, covering:
  - `/.well-known/lnurlp/...`
  - `/lnurlp/...`
  - `/verify/...`
  - `/webhook`

## Smoketest

The chart-level smoketest:

- Reads `blink_lnurl_server_endpoint` and `blink_lnurl_server_port` from smoketest settings.
- Retries `GET /health` up to 15 times.
- Checks `/.well-known/lnurlp/__smoketest__` for basic LNURL reachability.
- Accepts HTTP `200`, HTTP `404`, or expected not-found/domain/user response bodies.

It intentionally does not require a registered username. Full LNURL/Spark flow validation belongs to blinkbitcoin/blink-wip#792.

## Charts CI / Testflight

This PR adds `blink-lnurl-server` to the charts repo pipeline under a new `noncust` chart group instead of folding it into `addons`.

The generated pipeline now includes:

- `blink-lnurl-server-testflight`
- `bump-blink-lnurl-server-in-deployments`
- `blink-lnurl-server-chart`
- `tf-blink-lnurl-server-testflight`

The testflight fixture deploys:

- Bitnami PostgreSQL in the testflight namespace
- the `blink-lnurl-server` chart from `ci/testflight/blink-lnurl-server/chart`
- the required app secret keys:
  - `db-url`
  - `ssp-auth-seed`
- smoketest settings for:
  - `blink_lnurl_server_endpoint`
  - `blink_lnurl_server_port`

The deployment bump job depends on the `blink-deployments` vendir/module wiring from blinkbitcoin/blink-wip#789. Until that deployment-side target exists, the testflight job can validate this chart, but the automatic deployment bump will need #789 to land.

While testing `ci/repipe`, this PR also fixes the existing Helm dependency update-job generator so it preserves dependencies whose repository is `oci://...`. Without that, a repipe would remove live update jobs such as `bump-postgresql-*`, `bump-redis-galoy-chart`, `bump-mongodb-galoy-chart`, and `bump-router-galoy-chart`. The same fix skips directories under `charts/` that do not contain `Chart.yaml`, avoiding the stale `charts/cala` warning.

## Local Tilt testing

This PR adds `dev/noncust/Tiltfile`, which deploys:

- `blink-lnurl-server-postgresql` in `galoy-dev-noncust`
- `blink-lnurl-server` in `galoy-dev-noncust`
- `blink-lnurl-server-smoketest` settings in `galoy-dev-smoketest`

Run only this service stack:

```bash
tilt up -f dev/noncust/Tiltfile
```

Or run it as part of the full local dev stack:

```bash
tilt up -f dev/Tiltfile
```

After the service is healthy, the chart-level smoketest can be run from this repo with:

```bash
CHART=blink-lnurl-server ci/tasks/dev-smoketest-settings.sh
ci/tasks/blink-lnurl-server-smoketest.sh
```

The Tilt resource also exposes a local port-forward on `8080`, so `/health` can be checked with:

```bash
curl --location -f http://localhost:8080/health
```

## Reconciliation with #9212

blink-claw-bot also opened #9212 for the same task. I compared both PRs and reconciled the useful differences here.

Pulled into this PR from #9212:

- Real initial image digest instead of a placeholder digest.
- Polished chart description.
- Fuller `.helmignore` convention.
- Conditional rendering for optional `LNURL_CRL_URL`.

Intentionally kept from this PR:

- Optional secret refs for `LNURL_NSEC` and `LNURL_CA_CERT` use `optional: true`, which is better for externally managed secrets.
- Smoketest is more tolerant of expected LNURL not-found/domain/user responses, matching blinkbitcoin/blink-wip#787.

#9212 was closed as a duplicate after reconciliation.

## Validation

Static validation run locally:

```bash
helm lint charts/blink-lnurl-server
helm template blink-lnurl-server charts/blink-lnurl-server \
  --set secrets.dbUrl='postgres://user:pass@postgres:5432/lnurl' \
  --set secrets.sspAuthSeed='0000000000000000000000000000000000000000000000000000000000000000' \
  --set blinkLnurlServer.domains='lnurl.example.com'
helm template blink-lnurl-server charts/blink-lnurl-server \
  --values dev/noncust/blink-lnurl-server-values.yml
helm template blink-lnurl-server-postgresql bitnami/postgresql \
  --namespace galoy-dev-noncust \
  --values dev/noncust/postgresql-values.yml
bash -n ci/tasks/blink-lnurl-server-smoketest.sh
bash -n ci/repipe
git diff --check
tilt alpha tiltfile-result -f dev/noncust/Tiltfile
tilt alpha tiltfile-result -f dev/Tiltfile
helm template blink-lnurl-server charts/blink-lnurl-server \
  --set-string blinkLnurlServer.domains='lnurl.example.com\,lnurl2.example.com' \
  --set-string blinkLnurlServer.webhookDomain=''
helm template blink-lnurl-server charts/blink-lnurl-server \
  --set-string blinkLnurlServer.domains='' \
  --set-string blinkLnurlServer.webhookDomain=''
sed 's/${service_host}/blink-lnurl-server.testflight.svc.cluster.local/g' \
  ci/testflight/blink-lnurl-server/testflight-values.yml \
  > /tmp/blink-lnurl-server-testflight-values.yml
helm template blink-lnurl-server charts/blink-lnurl-server \
  --values /tmp/blink-lnurl-server-testflight-values.yml
ytt -f ci/pipeline.yml -f ci/pipeline-fragments.lib.yml -f ci/values.yml \
  > /tmp/charts-pipeline.yml
rg "blink-lnurl-server-testflight|bump-blink-lnurl-server-in-deployments|blink-lnurl-server-smoketest" \
  /tmp/charts-pipeline.yml
tofu fmt -check -recursive ci/testflight/blink-lnurl-server
for d in charts/*/; do [ -f "$d/Chart.yaml" ] || continue; chart=${d#charts/}; chart=${chart%/}; (cd "$d" && helm dependency list 2>/dev/null | grep -v WARNING | sort | uniq | tail -n +2 | awk '{ print chart, $1, $3 }' chart="$chart"); done | awk '$3 ~ /^(https?:\/\/|oci:\/\/)/ { print }' | sort
```

The final command is expected to fail and confirms the render-time guard:

```text
blinkLnurlServer.webhookDomain or blinkLnurlServer.domains is required
```

I also ran `tofu -chdir=ci/testflight/blink-lnurl-server init -backend=false`; provider installation succeeded. `tofu validate` could not complete locally because this OpenTofu build failed to instantiate the Kubernetes provider plugin, even with the provider pinned to the existing repo v2 line. The fixture was still format-checked and the chart/pipeline render paths above passed.

Live Tilt validation was run on a fresh local k3d cluster after manually clearing the old Docker containers:

```bash
tilt ci -f dev/noncust/Tiltfile --timeout 10m \
  --output-snapshot-on-exit /tmp/noncust-tilt-snapshot-seedfix.json
```

Result:

```text
SUCCESS. All workloads are healthy.
```

The live run caught and this PR now fixes:

- standalone `dev/noncust/Tiltfile` needed to create `galoy-dev-smoketest`
- dev-only `ssp-auth-seed` could not be all numeric because the app config parser treated the all-zero value as an unsigned integer instead of a string

GitHub checks are passing:

- `fmt`
- `helm-lint`

## Related

- blinkbitcoin/blink-wip#787
- blinkbitcoin/blink-wip#786
