### PR TITLE
fix(blink-lnurl-server): wire deployment env runtime config

### DIFF
--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -50,10 +50,19 @@ spec:
           value: {{ .Values.blinkLnurlServer.address | quote }}
         - name: LNURL_AUTO_MIGRATE
           value: {{ .Values.blinkLnurlServer.autoMigrate | quote }}
+        - name: DEPLOYMENT_ENV
+          value: {{ .Values.blinkLnurlServer.deploymentEnv | quote }}
         - name: LNURL_DOMAINS
           value: {{ .Values.blinkLnurlServer.domains | quote }}
-        - name: LNURL_NETWORK
-          value: {{ .Values.blinkLnurlServer.network | quote }}
+{{- $sparkNetwork := .Values.blinkLnurlServer.sparkNetwork | default .Values.blinkLnurlServer.network }}
+{{- if $sparkNetwork }}
+        - name: LNURL_SPARK_NETWORK
+          value: {{ $sparkNetwork | quote }}
+{{- end }}
+{{- if .Values.blinkLnurlServer.blinkGraphqlEndpoint }}
+        - name: LNURL_BLINK_GRAPHQL_ENDPOINT
+          value: {{ .Values.blinkLnurlServer.blinkGraphqlEndpoint | quote }}
+{{- end }}
         - name: LNURL_SCHEME
           value: {{ .Values.blinkLnurlServer.scheme | quote }}
         - name: LNURL_WEBHOOK_DOMAIN

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -8,8 +8,10 @@ secrets:
 blinkLnurlServer:
   address: "0.0.0.0:8080"
   autoMigrate: "true"
+  deploymentEnv: "production"
   domains: "localhost:8080"
-  network: "mainnet"
+  sparkNetwork: ""
+  blinkGraphqlEndpoint: ""
   scheme: "https"
   webhookDomain: ""
   logLevel: "info"

--- a/ci/testflight/blink-lnurl-server/testflight-values.yml
+++ b/ci/testflight/blink-lnurl-server/testflight-values.yml
@@ -2,8 +2,8 @@ secrets:
   create: false
 
 blinkLnurlServer:
+  deploymentEnv: "staging"
   domains: "${service_host}:8080"
-  network: "regtest"
   scheme: "http"
   webhookDomain: "${service_host}:8080"
   logLevel: "debug"

--- a/dev/noncust/blink-lnurl-server-values.yml
+++ b/dev/noncust/blink-lnurl-server-values.yml
@@ -2,8 +2,8 @@ secrets:
   create: false
 
 blinkLnurlServer:
+  deploymentEnv: "staging"
   domains: "blink-lnurl-server.galoy-dev-noncust.svc.cluster.local:8080"
-  network: "regtest"
   scheme: "http"
   webhookDomain: "blink-lnurl-server.galoy-dev-noncust.svc.cluster.local:8080"
   logLevel: "debug"


### PR DESCRIPTION
## Summary
- add `DEPLOYMENT_ENV` to the blink-lnurl-server chart
- replace emitted `LNURL_NETWORK` with optional `LNURL_SPARK_NETWORK`
- add optional `LNURL_BLINK_GRAPHQL_ENDPOINT`
- update dev/testflight values to use `staging`