### PR TITLE
feat(blink-lnurl-server): add LNURL spark and blink enabled env vars

### DIFF
--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           value: {{ .Values.blinkLnurlServer.autoMigrate | quote }}
         - name: DEPLOYMENT_ENV
           value: {{ .Values.blinkLnurlServer.deploymentEnv | quote }}
+        - name: LNURL_SPARK_ENABLED
+          value: {{ .Values.blinkLnurlServer.sparkEnabled | quote }}
+        - name: LNURL_BLINK_ENABLED
+          value: {{ .Values.blinkLnurlServer.blinkEnabled | quote }}
         - name: LNURL_DOMAINS
           value: {{ .Values.blinkLnurlServer.domains | quote }}
 {{- $sparkNetwork := .Values.blinkLnurlServer.sparkNetwork | default .Values.blinkLnurlServer.network }}

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -8,6 +8,8 @@ blinkLnurlServer:
   address: "0.0.0.0:8080"
   autoMigrate: "true"
   deploymentEnv: "production"
+  sparkEnabled: "true"
+  blinkEnabled: "true"
   domains: "localhost:8080"
   sparkNetwork: ""
   blinkGraphqlEndpoint: ""


### PR DESCRIPTION
## Summary

Add `LNURL_SPARK_ENABLED` and `LNURL_BLINK_ENABLED` to the `blink-lnurl-server` chart and default both to `true`.

## Changes

- add `blinkLnurlServer.sparkEnabled` default in `values.yaml`
- add `blinkLnurlServer.blinkEnabled` default in `values.yaml`
- wire both values into the deployment template as:
  - `LNURL_SPARK_ENABLED`
  - `LNURL_BLINK_ENABLED`