### PR TITLE
feat(blink-lnurl-server): add internal auth env vars

### DIFF
--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -83,6 +83,22 @@ spec:
         - name: LNURL_CRL_URL
           value: {{ .Values.blinkLnurlServer.crlUrl | quote }}
 {{- end }}
+{{- if .Values.blinkLnurlServer.internalJwksUrl }}
+        - name: LNURL_INTERNAL_JWKS_URL
+          value: {{ .Values.blinkLnurlServer.internalJwksUrl | quote }}
+{{- end }}
+{{- if .Values.blinkLnurlServer.internalJwksPath }}
+        - name: LNURL_INTERNAL_JWKS_PATH
+          value: {{ .Values.blinkLnurlServer.internalJwksPath | quote }}
+{{- end }}
+{{- if .Values.blinkLnurlServer.internalJwtIssuer }}
+        - name: LNURL_INTERNAL_JWT_ISSUER
+          value: {{ .Values.blinkLnurlServer.internalJwtIssuer | quote }}
+{{- end }}
+{{- if .Values.blinkLnurlServer.internalJwtAudience }}
+        - name: LNURL_INTERNAL_JWT_AUDIENCE
+          value: {{ .Values.blinkLnurlServer.internalJwtAudience | quote }}
+{{- end }}
         - name: LNURL_DB_URL
           valueFrom:
             secretKeyRef:

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -20,6 +20,10 @@ blinkLnurlServer:
   maxSendable: "4000000000"
   webhookDeliveryTtlDays: "90"
   crlUrl: ""
+  internalJwksUrl: ""
+  internalJwksPath: ""
+  internalJwtIssuer: ""
+  internalJwtAudience: ""
 image:
   repository: us.gcr.io/galoy-org/blink-lnurl-server
   digest: "sha256:7ac94fec29646806625e26b2a1e2a583cb082dd03d986c5af6a37f37b3847202" # METADATA:: repository=https://github.com/blinkbitcoin/blink-lnurl-server;commit_ref=385cae7;app=blink-lnurl-server;


### PR DESCRIPTION
## Summary

Add support for the missing `LNURL_INTERNAL_*` configuration variables in the `blink-lnurl-server` chart.

## Changes

- add `blinkLnurlServer.internalJwksUrl` default in `values.yaml`
- add `blinkLnurlServer.internalJwksPath` default in `values.yaml`
- add `blinkLnurlServer.internalJwtIssuer` default in `values.yaml`
- add `blinkLnurlServer.internalJwtAudience` default in `values.yaml`
- wire these values into the deployment template as:
  - `LNURL_INTERNAL_JWKS_URL`
  - `LNURL_INTERNAL_JWKS_PATH`
  - `LNURL_INTERNAL_JWT_ISSUER`
  - `LNURL_INTERNAL_JWT_AUDIENCE`