### PR TITLE
feat(galoy): add lnurl server envs

### DIFF
--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -112,6 +112,10 @@ spec:
           value: notifications
         - name: NOTIFICATIONS_PORT
           value: {{ .Values.galoy.notifications.grpcPort | quote }}
+        - name: LNURL_SERVER_LN_ADDRESS_DOMAIN
+          value: {{ .Values.galoy.lnurlServer.lnAddressDomain | quote }}
+        - name: LNURL_SERVER_INTERNAL_URL
+          value: {{ .Values.galoy.lnurlServer.internalUrl | quote }}
 
         - name: API_KEYS_HOST
           value: api-keys

--- a/charts/galoy/templates/exporter-deployment.yaml
+++ b/charts/galoy/templates/exporter-deployment.yaml
@@ -108,6 +108,10 @@ spec:
           value: notifications
         - name: NOTIFICATIONS_PORT
           value: {{ .Values.galoy.notifications.grpcPort | quote }}
+        - name: LNURL_SERVER_LN_ADDRESS_DOMAIN
+          value: {{ .Values.galoy.lnurlServer.lnAddressDomain | quote }}
+        - name: LNURL_SERVER_INTERNAL_URL
+          value: {{ .Values.galoy.lnurlServer.internalUrl | quote }}
 
         - name: API_KEYS_HOST
           value: api-keys

--- a/charts/galoy/templates/galoy-cronjob.yaml
+++ b/charts/galoy/templates/galoy-cronjob.yaml
@@ -54,6 +54,10 @@ spec:
               value: notifications
             - name: NOTIFICATIONS_PORT
               value: {{ .Values.galoy.notifications.grpcPort | quote }}
+            - name: LNURL_SERVER_LN_ADDRESS_DOMAIN
+              value: {{ .Values.galoy.lnurlServer.lnAddressDomain | quote }}
+            - name: LNURL_SERVER_INTERNAL_URL
+              value: {{ .Values.galoy.lnurlServer.internalUrl | quote }}
 
             - name: API_KEYS_HOST
               value: api-keys

--- a/charts/galoy/templates/trigger-deployment.yaml
+++ b/charts/galoy/templates/trigger-deployment.yaml
@@ -101,6 +101,10 @@ spec:
           value: notifications
         - name: NOTIFICATIONS_PORT
           value: {{ .Values.galoy.notifications.grpcPort | quote }}
+        - name: LNURL_SERVER_LN_ADDRESS_DOMAIN
+          value: {{ .Values.galoy.lnurlServer.lnAddressDomain | quote }}
+        - name: LNURL_SERVER_INTERNAL_URL
+          value: {{ .Values.galoy.lnurlServer.internalUrl | quote }}
 
         - name: API_KEYS_HOST
           value: api-keys

--- a/charts/galoy/templates/websocket-deployment.yaml
+++ b/charts/galoy/templates/websocket-deployment.yaml
@@ -84,6 +84,10 @@ spec:
           value: notifications
         - name: NOTIFICATIONS_PORT
           value: {{ .Values.galoy.notifications.grpcPort | quote }}
+        - name: LNURL_SERVER_LN_ADDRESS_DOMAIN
+          value: {{ .Values.galoy.lnurlServer.lnAddressDomain | quote }}
+        - name: LNURL_SERVER_INTERNAL_URL
+          value: {{ .Values.galoy.lnurlServer.internalUrl | quote }}
 
         - name: API_KEYS_HOST
           value: api-keys

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -463,6 +463,9 @@ galoy:
         accountLivenessThresholdMinutes: 30240
         accountAgeThresholdMinutes: 30240
         notificationCoolOffThresholdMinutes: 129600
+  lnurlServer:
+    lnAddressDomain: blink-lnurl-server:8080
+    internalUrl: http://galoy-oathkeeper-proxy:4455/lnurl-internal
   consent:
     resources: {}
     port: 80
@@ -956,6 +959,26 @@ oathkeeper:
           - handler: id_token
             config:
               claims: '{"sub": "{{ print .Subject }}", "scope": "{{ print .Extra.scope }}" }'
+      - id: blink-lnurl-server-internal
+        upstream:
+          url: http://blink-lnurl-server:8080
+          strip_path: /lnurl-internal
+        match:
+          url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/lnurl-internal/<.*>"
+          methods:
+            - GET
+            - POST
+            - PUT
+            - PATCH
+            - DELETE
+        authenticators:
+          - handler: anonymous
+        authorizer:
+          handler: allow
+        mutators:
+          - handler: id_token
+            config:
+              claims: '{"sub":"galoy-api","aud":"blink-lnurl-server","scope":"blink:accounts:create blink:accounts:read blink:accounts:update blink:transfers:write"}'
   maester:
     enabled: false
 kratos:


### PR DESCRIPTION
## Summary

- add `LNURL_SERVER_LN_ADDRESS_DOMAIN` and `LNURL_SERVER_INTERNAL_URL` to Galoy workloads
- route LNURL internal calls through `galoy-oathkeeper-proxy`
- add the Oathkeeper `/lnurl-internal` access rule for `blink-lnurl-server`