### PR TITLE
chore: set lnurl internalUrl default to empty string

### DIFF
--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -465,7 +465,7 @@ galoy:
         notificationCoolOffThresholdMinutes: 129600
   lnurlServer:
     lnAddressDomain: blink-lnurl-server:8080
-    internalUrl: http://galoy-oathkeeper-proxy:4455/lnurl-internal
+    internalUrl: "" # http://galoy-oathkeeper-proxy:4455/lnurl-internal
   consent:
     resources: {}
     port: 80


### PR DESCRIPTION
## Summary

- change `galoy.lnurlServer.internalUrl` default from `http://galoy-oathkeeper-proxy:4455/lnurl-internal` to `""`
- keep the previous internal URL as an inline comment for reference