### PR TITLE
feat(blink-lnurl-server): add LNURL_CALLBACK_DOMAIN env var

### DIFF
--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
           value: {{ .Values.blinkLnurlServer.blinkEnabled | quote }}
         - name: LNURL_DOMAINS
           value: {{ .Values.blinkLnurlServer.domains | quote }}
+        - name: LNURL_CALLBACK_DOMAIN
+          value: {{ .Values.blinkLnurlServer.callbackDomain | quote }}
 {{- $sparkNetwork := .Values.blinkLnurlServer.sparkNetwork | default .Values.blinkLnurlServer.network }}
 {{- if $sparkNetwork }}
         - name: LNURL_SPARK_NETWORK

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -11,6 +11,7 @@ blinkLnurlServer:
   sparkEnabled: "true"
   blinkEnabled: "true"
   domains: "localhost:8080"
+  callbackDomain: ""
   sparkNetwork: ""
   blinkGraphqlEndpoint: ""
   scheme: "https"


### PR DESCRIPTION
## Summary

Add support for configuring `LNURL_CALLBACK_DOMAIN` in the `blink-lnurl-server` chart.

## Changes

- add `blinkLnurlServer.callbackDomain` to chart values
- wire `LNURL_CALLBACK_DOMAIN` into the deployment env

## Verification

- `rtk helm template test charts/blink-lnurl-server`
- `rtk helm template test charts/blink-lnurl-server -f dev/noncust/blink-lnurl-server-values.yml`