### PR TITLE
fix(bitcoind): make liveness probe optional and shutdown grace configurable for IBD

### DIFF
--- a/charts/bitcoind/Chart.yaml
+++ b/charts/bitcoind/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1-dev
+version: 0.6.2-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/bitcoind/templates/service.yaml
+++ b/charts/bitcoind/templates/service.yaml
@@ -15,7 +15,9 @@ spec:
       port: {{ .Values.service.ports.zmqpubrawtx }}
     - name: zmqpubrawblock
       port: {{ .Values.service.ports.zmqpubrawblock }}
+    {{- if .Values.exporter.enabled }}
     - name: metrics
       port: {{ .Values.service.ports.metrics }}
+    {{- end }}
   selector:
     {{- include "bitcoind.selectorLabels" . | nindent 4 }}

--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -23,9 +23,11 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ $checksum }}
+        {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: {{ $.Values.service.ports.metrics | quote }}
         prometheus.io/scrape: "true"
+        {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -217,6 +219,7 @@ spec:
               mountPath: /data/.bitcoin/bitcoin.conf
               subPath: bitcoin.conf
         {{- end }}
+        {{- if .Values.exporter.enabled }}
         - name: exporter
           image: jvstein/bitcoin-prometheus-exporter:v0.6.0
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -246,6 +249,7 @@ spec:
             httpGet:
               path: /
               port: metrics
+        {{- end }}
       volumes:
         - name: config
           emptyDir: {}

--- a/charts/bitcoind/templates/statefulset.yaml
+++ b/charts/bitcoind/templates/statefulset.yaml
@@ -42,6 +42,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "bitcoind.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
@@ -104,6 +105,7 @@ spec:
             failureThreshold: {{.Values.startupProbe.failureThreshold}}
             periodSeconds: {{.Values.startupProbe.periodSeconds}}
             timeoutSeconds: {{.Values.startupProbe.timeoutSeconds}}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
@@ -117,6 +119,7 @@ spec:
             periodSeconds: {{.Values.livenessProbe.periodSeconds}}
             failureThreshold: {{.Values.livenessProbe.failureThreshold}}
             timeoutSeconds: {{.Values.livenessProbe.timeoutSeconds}}
+          {{- end }}
           readinessProbe:
             exec:
               command:

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -52,6 +52,13 @@ service:
     p2p: 8333
     metrics: 3000
 
+exporter:
+  # The prometheus exporter polls bitcoind over RPC and exits when RPC is
+  # slow to answer, which crash-loops the sidecar during initial block
+  # download while adding RPC load bitcoind can least afford. Disable it
+  # for syncing deployments and re-enable once at the tip.
+  enabled: true
+
 ingress:
   enabled: false
   annotations: {}

--- a/charts/bitcoind/values.yaml
+++ b/charts/bitcoind/values.yaml
@@ -133,12 +133,23 @@ withdrawalDescriptor:
   secretName: ""
   secretKey: ""
 
+# bitcoind flushes the UTXO cache (up to dbcache MiB of dirty state) on
+# shutdown; the Kubernetes default of 30s SIGKILLs it mid-flush and the next
+# start pays a full chainstate replay. Size generously.
+terminationGracePeriodSeconds: 600
+
 startupProbe:
   failureThreshold: 180
   periodSeconds: 10
   timeoutSeconds: 10
 
 livenessProbe:
+  # During initial block download, block validation can hold the RPC lock
+  # for many minutes at a time, so even generous exec timeouts get exceeded
+  # and kubelet kills a healthy, progressing node; each kill also discards
+  # the warm UTXO cache and forces a chainstate replay. Set enabled: false
+  # for deployments that still need to sync; re-enable once at the tip.
+  enabled: true
   initialDelaySeconds: 120
   periodSeconds: 30
   failureThreshold: 5


### PR DESCRIPTION
During initial block download bitcoind holds the RPC lock through long validation stretches, so the liveness exec probe times out and kubelet repeatedly kills a healthy, progressing node. Each kill also SIGKILLed the shutdown UTXO flush after the default 30s grace, forcing a 20-40 min chainstate replay on restart (measured on a signet node: 5 kills in 90 min, net sync progress near zero).

Add livenessProbe.enabled (default true) and terminationGracePeriodSeconds (default 600). Syncing deployments set enabled: false and re-enable once at the tip.