### PR TITLE
chore-bump-blink-terminal-image-f940286

### DIFF
--- a/charts/blink-terminal/Chart.yaml
+++ b/charts/blink-terminal/Chart.yaml
@@ -3,7 +3,7 @@ name: blink-terminal
 description: A Helm chart for the blink-terminal (BlinkPOS) merchant terminal
 type: application
 version: 0.1.0-dev
-appVersion: 0.6.4
+appVersion: 0.6.5
 dependencies:
   - name: postgresql
     version: 18.5.2

--- a/charts/blink-terminal/values.yaml
+++ b/charts/blink-terminal/values.yaml
@@ -25,7 +25,7 @@ blinkTerminal:
   tracingServiceName: "blink-terminal"
 image:
   repository: us.gcr.io/galoy-org/blink-terminal
-  digest: "sha256:d57e7382c906c8b689c55ab6a04cff9d89c9cf360e8add3bac4d9c7f10a4e6d0" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=d143445;app=blink-terminal;
+  digest: "sha256:6baf48178ccf3e9791fa8e06daf5eab00eda9a55fe3dac20d79ecee7659c1c2d" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=f940286;app=blink-terminal;
 psqlImage: "postgres:15"
 ingress:
   enabled: false


### PR DESCRIPTION
# Bump blink-terminal image

The blink-terminal image will be bumped to digest:


Code diff contained in this image:

https://github.com/blinkbitcoin/blink-terminal/compare/d143445...f940286
