### PR TITLE
chore-bump-blink-terminal-image-2157bb6

### DIFF
--- a/charts/blink-terminal/Chart.yaml
+++ b/charts/blink-terminal/Chart.yaml
@@ -3,7 +3,7 @@ name: blink-terminal
 description: A Helm chart for the blink-terminal (BlinkPOS) merchant terminal
 type: application
 version: 0.1.0-dev
-appVersion: 0.7.2
+appVersion: 0.7.3
 dependencies:
   - name: postgresql
     version: 18.5.2

--- a/charts/blink-terminal/values.yaml
+++ b/charts/blink-terminal/values.yaml
@@ -25,7 +25,7 @@ blinkTerminal:
   tracingServiceName: "blink-terminal"
 image:
   repository: us.gcr.io/galoy-org/blink-terminal
-  digest: "sha256:2ec9c6eab64ea39d1e778ab19cde717255ded3e8d9a1a45346a1cb75cc89cd08" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=33bab16;app=blink-terminal;
+  digest: "sha256:8ee0a15f9107d199d3072970ab89b6f9ee60e74732e0022d5a59fd990f0b7be1" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=2157bb6;app=blink-terminal;
 psqlImage: "postgres:15"
 ingress:
   enabled: false


### PR DESCRIPTION
# Bump blink-terminal image

The blink-terminal image will be bumped to digest:


Code diff contained in this image:

https://github.com/blinkbitcoin/blink-terminal/compare/33bab16...2157bb6
