### PR TITLE
feat(galoy): optional PHONE_HASH_SECRET for api

### DIFF
--- a/charts/galoy/templates/_helpers.tpl
+++ b/charts/galoy/templates/_helpers.tpl
@@ -209,6 +209,24 @@ Define kratos env vars
   value: {{ .Values.galoy.kratos.adminApiUrl | quote }}
 {{- end -}}
 
+{{/*
+Define phone hash env vars
+
+Pepper for the keyed hashes that pseudonymize phone numbers in logs and traces.
+The api falls back to a public dev default when this is unset, which makes the
+digests reversible by enumerating the E.164 space -- deployed environments must
+provide the secret.
+*/}}
+{{- define "galoy.phoneHash.env" -}}
+{{- if .Values.galoy.phoneHash.existingSecret.name }}
+- name: PHONE_HASH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.phoneHash.existingSecret.name }}
+      key: {{ .Values.galoy.phoneHash.existingSecret.key }}
+{{- end }}
+{{- end -}}
+
 {{- define "galoy.bria.env" -}}
 - name: BRIA_HOST
   value: {{ .Values.galoy.bria.host | quote }}

--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -104,6 +104,7 @@ spec:
 {{ include "galoy.telegram.env" . | indent 8 }}
 
 {{ include "galoy.kratos.env" . | indent 8 }}
+{{ include "galoy.phoneHash.env" . | indent 8 }}
 
         - name: OATHKEEPER_DECISION_ENDPOINT
           value: http://galoy-oathkeeper-api:4456

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -492,6 +492,15 @@ galoy:
       name: kratos-secret
       master_user_password: master_user_password
       callback_api_key: callback_api_key
+  ## Pepper for the keyed hashes that pseudonymize phone numbers in logs and traces.
+  ## Leave the name empty to omit the env var entirely; the api then falls back to a
+  ## public dev default, which makes the digests reversible by enumerating the E.164
+  ## space. Deployed environments should point this at a provisioned secret.
+  ##
+  phoneHash:
+    existingSecret:
+      name: ""
+      key: phone_hash_secret
   ## Configuration values for establishing connection to LND-1
   ## TODO: This should be injected as ConfigMap from LND Chart
   ##


### PR DESCRIPTION
Chart side of [blinkbitcoin/blink#157](https://github.com/blinkbitcoin/blink/pull/157).

That PR adds an admin `phoneRateLimitReset` mutation which writes an audit record. The record has to identify *which* user was unblocked without putting a raw phone number in pino logs or Honeycomb. A bare `sha256(phone)` does not achieve that — E.164 is small enough to enumerate on a GPU in minutes — so the api uses `HMAC-SHA256(PHONE_HASH_SECRET, phone)`. This exposes that pepper to the api.

## Changes

* `galoy.phoneHash.env` helper in `_helpers.tpl`, rendering `PHONE_HASH_SECRET` from a `secretKeyRef`.
* Included in `api-deployment.yaml` only — the admin mutation is the sole caller.
* `galoy.phoneHash.existingSecret` in `values.yaml`, **defaulting to an empty name**.

## Empty default is deliberate

With no name set the env var is omitted entirely and the api falls back to its dev default, so existing installs are unaffected. A `secretKeyRef` pointing at a secret that was never provisioned would leave pods stuck in `CreateContainerConfigError`.

The tradeoff: deployments must opt in explicitly. For Blink that is a `random_password` + `kubernetes_secret` in `modules/galoy` plus the values override, documented in `docs/hash-pepper-for-sha256.md` in blink-deployments. Anyone not setting it keeps a reversible digest, which is why the api-side default is named `dev-phone-hash-secret` and the values comment says so plainly.

## Verification

`helm template` via the repo flake, both branches of the conditional:

* default values → 0 occurrences of `PHONE_HASH_SECRET`, renders clean
* `--set galoy.phoneHash.existingSecret.name=phone-hash-secret` → 1 occurrence, in the api deployment:

```yaml
- name: PHONE_HASH_SECRET
  valueFrom:
    secretKeyRef:
      name: phone-hash-secret
      key: phone_hash_secret
```

Merge order does not matter — the api tolerates the var being absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)