### PR TITLE
feat(blink-lnurl-server): add ingress.annotations passthrough

### DIFF
--- a/charts/blink-lnurl-server/templates/ingress.yaml
+++ b/charts/blink-lnurl-server/templates/ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     release: "{{ .Release.Name }}"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-issuer
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -39,6 +39,9 @@ ingress:
   hosts: []
   rulesOverride: null
   extraTls: []
+  # Additional annotations merged onto the Ingress (e.g. nginx rate-limit / server-snippet).
+  # cert-manager.io/cluster-issuer is always set by the template and need not be repeated here.
+  annotations: {}
 service:
   port: 8080
   type: ClusterIP


### PR DESCRIPTION
## Summary
Add an optional `ingress.annotations` passthrough to the `blink-lnurl-server` chart so operators can attach nginx ingress annotations via values, without forking the vendored chart.

## Motivation
We need to apply path-scoped rate limiting to `lnurl.blink.sv/verify/*` (see blinkbitcoin/blink-wip#1123 — runaway LUD-21 verify polling from BTCPay plugins). The rate limit is implemented as an ingress-nginx `server-snippet` annotation on the lnurl-server Ingress, but the chart currently hardcodes its annotations block with no passthrough.

## Change
- `templates/ingress.yaml`: merge `.Values.ingress.annotations` under the existing `cert-manager.io/cluster-issuer` default.
- `values.yaml`: document the new `ingress.annotations` field (default `{}`).

Fully backward-compatible: when `ingress.annotations` is unset the rendered manifest is unchanged.

## Validation
Rendered locally with `helm template`:
```
annotations:
  cert-manager.io/cluster-issuer: letsencrypt-issuer
  nginx.ingress.kubernetes.io/server-snippet: location ~ ^/verify/ { return 429; }
```
The companion `blinkbitcoin/blink-deployments` change (staging) wires the actual rate-limit zone + snippet.