### PR TITLE
feat(blink-lnurl-server): wire proxycheck key and mode rate-limit env vars

### DIFF
--- a/charts/blink-lnurl-server/templates/deployment.yaml
+++ b/charts/blink-lnurl-server/templates/deployment.yaml
@@ -141,5 +141,19 @@ spec:
               name: {{ template "blink-lnurl-server.fullname" . }}
               key: "ca-cert"
               optional: true
+        - name: LNURL_PROXYCHECK_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "blink-lnurl-server.fullname" . }}
+              key: "proxycheck-api-key"
+              optional: true
+{{- if .Values.blinkLnurlServer.modeRequestsPerIpPerMinute }}
+        - name: LNURL_MODE_REQUESTS_PER_IP_PER_MINUTE
+          value: {{ .Values.blinkLnurlServer.modeRequestsPerIpPerMinute | quote }}
+{{- end }}
+{{- if .Values.blinkLnurlServer.countryLookupsPerDay }}
+        - name: LNURL_COUNTRY_LOOKUPS_PER_DAY
+          value: {{ .Values.blinkLnurlServer.countryLookupsPerDay | quote }}
+{{- end }}
         resources:
           {{ toYaml .Values.resources | nindent 10 }}

--- a/charts/blink-lnurl-server/templates/secrets.yaml
+++ b/charts/blink-lnurl-server/templates/secrets.yaml
@@ -17,4 +17,7 @@ data:
   {{- if .Values.secrets.caCert }}
   ca-cert: {{ .Values.secrets.caCert | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.proxycheckApiKey }}
+  proxycheck-api-key: {{ .Values.secrets.proxycheckApiKey | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/blink-lnurl-server/values.yaml
+++ b/charts/blink-lnurl-server/values.yaml
@@ -4,6 +4,7 @@ secrets:
   sspAuthSeed: ""
   nsec: ""
   caCert: ""
+  proxycheckApiKey: ""
 blinkLnurlServer:
   address: "0.0.0.0:8080"
   autoMigrate: "true"
@@ -25,6 +26,8 @@ blinkLnurlServer:
   internalJwksPath: ""
   internalJwtIssuer: ""
   internalJwtAudience: ""
+  modeRequestsPerIpPerMinute: ""
+  countryLookupsPerDay: ""
 waitForInternalJwks:
   enabled: false
   image: curlimages/curl:8.10.1


### PR DESCRIPTION
blink-lnurl-server 0.7.1 (the account-mode release) reads `LNURL_PROXYCHECK_API_KEY` to resolve country evidence for enhanced-mode accounts, plus two rate-limit tunables. This adds the chart plumbing for all three.

The key follows the existing `nsec`/`ca-cert` idiom: an `optional: true` secretKeyRef on the release secret, so environments without the key deploy unchanged and the server boots with country resolution disabled (its documented fallback — modes and gating still work, evidence columns stay NULL). The rate-limit envs render only when the values are set, keeping the server's own defaults (10/min/IP, 5000/day) authoritative rather than duplicating them in chart values.

The full path this enables was already proven on staging via a temporary `kubectl set env` override: key + egress + `x-real-ip` chain validated end to end (country evidence recorded correctly). The terraform side that feeds `proxycheck-api-key` into the secret is a companion blink-deployments PR.